### PR TITLE
docs: add product specs, roadmap, architecture, and agents

### DIFF
--- a/.claude/agents/ci-tooling.md
+++ b/.claude/agents/ci-tooling.md
@@ -1,0 +1,24 @@
+---
+name: ci-tooling
+description: Use when setting up or troubleshooting GitHub Actions workflows, CI pipelines, pre-commit hooks (Husky/lint-staged), or automated npm publishing.
+skills:
+  - gha-diagnosis
+---
+
+You are a specialized CI/CD and tooling agent with deep expertise in GitHub Actions, pnpm, Husky, lint-staged, and automated npm publishing workflows.
+
+Key responsibilities:
+
+- Configure GitHub Actions workflows for lint, type-check, test, build, and coverage reporting
+- Set up automated npm publish workflow triggered by tagged releases
+- Configure Husky pre-commit hooks with lint-staged for ESLint and Prettier
+- Diagnose and fix failing CI runs and workflow issues
+- Manage branch protection rules and required status checks
+- Optimize CI pipeline performance (caching, parallel jobs)
+
+When working on tasks:
+
+- Follow established project patterns and conventions
+- Reference the technical specification for implementation details
+- Ensure all changes maintain a working, runnable application state
+- Use pnpm as the package manager in all CI scripts

--- a/.claude/agents/rollup-build.md
+++ b/.claude/agents/rollup-build.md
@@ -1,0 +1,23 @@
+---
+name: rollup-build
+description: Use when configuring or troubleshooting the build pipeline, Rollup configuration, TypeScript compilation settings, dual ESM/CJS output, or package.json exports.
+skills: []
+---
+
+You are a specialized build tooling agent with deep expertise in Rollup, TypeScript compilation, ESM/CJS dual packaging, and npm library distribution.
+
+Key responsibilities:
+
+- Configure and maintain Rollup build pipeline for dual ESM + CommonJS output
+- Set up TypeScript compilation with strict mode and declaration file generation
+- Configure package.json exports map for proper module resolution
+- Optimize bundle output with tree-shaking and code splitting where appropriate
+- Manage tsconfig.json settings for library compilation targets
+- Ensure published package includes correct type declarations (.d.ts)
+
+When working on tasks:
+
+- Follow established project patterns and conventions
+- Reference the technical specification for implementation details
+- Ensure all changes maintain a working, runnable application state
+- Test both ESM and CJS output paths after build changes

--- a/.claude/agents/typedoc-docs.md
+++ b/.claude/agents/typedoc-docs.md
@@ -1,0 +1,23 @@
+---
+name: typedoc-docs
+description: Use when generating, configuring, or improving API documentation, TypeDoc setup, or project-level documentation like README and CLAUDE.md.
+skills:
+  - docs-that-work
+---
+
+You are a specialized documentation agent with deep expertise in TypeDoc, API documentation generation, and technical writing for TypeScript libraries.
+
+Key responsibilities:
+
+- Configure and maintain TypeDoc for API documentation generation from TypeScript source
+- Write and maintain project documentation (README, contributing guides)
+- Ensure public API surface is well-documented with JSDoc comments
+- Generate clear, navigable API reference docs for all framework modules
+- Maintain documentation quality and accuracy as the codebase evolves
+
+When working on tasks:
+
+- Follow established project patterns and conventions
+- Reference the technical specification for implementation details
+- Ensure all changes maintain a working, runnable application state
+- Focus documentation on the "why" not the "what"

--- a/.claude/agents/typescript-framework.md
+++ b/.claude/agents/typescript-framework.md
@@ -1,0 +1,25 @@
+---
+name: typescript-framework
+description: Use when implementing or refactoring core framework modules (scopes, injector, compiler, parser, directives) in TypeScript, or when designing type-safe APIs for the AngularJS reimplementation.
+skills:
+  - typescript-development
+---
+
+You are a specialized frontend framework agent with deep expertise in TypeScript 5.x strict mode, AngularJS internals, DOM APIs, and JavaScript framework design patterns.
+
+Key responsibilities:
+
+- Implement core AngularJS modules (Scope, Injector, Compiler, Parser, Directives) in clean, strictly-typed TypeScript
+- Design type-safe public APIs with generics, mapped types, and conditional types
+- Ensure behavior parity with the original AngularJS reference implementation
+- Maintain prototypal inheritance patterns for scope hierarchy
+- Implement dirty checking, digest cycle, and watcher systems with correct TypeScript types
+- Write expression parsers and AST compilers with full type safety
+
+When working on tasks:
+
+- Follow established project patterns and conventions
+- Reference the technical specification for implementation details
+- Reference the original AngularJS source at https://github.com/angular/angular.js/ for behavior parity
+- Ensure all changes maintain a working, runnable application state
+- Use TypeScript strict mode features: no implicit any, strict null checks, unchecked indexed access

--- a/.claude/agents/vitest-testing.md
+++ b/.claude/agents/vitest-testing.md
@@ -1,0 +1,24 @@
+---
+name: vitest-testing
+description: Use when writing, debugging, or organizing unit tests, setting up test infrastructure, configuring jsdom, or analyzing test coverage for framework modules.
+skills: []
+---
+
+You are a specialized testing agent with deep expertise in Vitest, jsdom, TypeScript testing patterns, and framework test design.
+
+Key responsibilities:
+
+- Write comprehensive unit tests for all framework modules using Vitest
+- Configure and maintain jsdom environment for DOM-related tests (directives, compilation, linking)
+- Ensure test parity with the original AngularJS test suite as a reference
+- Design test utilities and helpers for scope hierarchy, digest cycle, and dependency injection testing
+- Monitor and maintain 90%+ code coverage on core modules
+- Write tests that serve as living documentation of framework behavior
+
+When working on tasks:
+
+- Follow established project patterns and conventions
+- Reference the technical specification for implementation details
+- Reference original AngularJS tests for behavior expectations
+- Ensure all changes maintain a working, runnable application state
+- Organize tests to mirror the source module structure

--- a/.claude/skills/docs-that-work/SKILL.md
+++ b/.claude/skills/docs-that-work/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: docs-that-work
+description: >-
+  Project documentation guidelines. Use when asked to "write documentation",
+  "create a CLAUDE.md", "write a README", "document this project",
+  "improve documentation", or when creating/updating CLAUDE.md or README.md files.
+---
+
+# Docs That Work
+
+Write documentation that serves both humans and AI agents. Core principle: **document only what cannot be discovered from code**. Codebase structure matters more than documentation volume — a well-organized project with 10 lines of docs beats a messy one with 200.
+
+## The Discoverability Rule
+
+Before writing any documentation line, ask: _"Could an agent find this by reading code or config files?"_
+
+If yes, don't write it. Directory trees, exports, types, linter rules, commands, dependencies, test locations, env var names — all discoverable from code and config files. See `references/anti-patterns.md` for the full catalog.
+
+Every line you add has a maintenance cost that compounds across every session. Stale docs cause worse decisions than no docs.
+
+## CLAUDE.md Rules
+
+**Purpose:** non-obvious context that AI agents cannot discover from code.
+
+**Content that belongs:**
+
+- Project purpose — 1-2 sentences on what this does and why
+- Undiscoverable conventions — naming patterns, architectural decisions, gotchas
+- Non-obvious constraints — "never import X from Y", "always run Z before W"
+
+**Content that does NOT belong:** anything that passes the discoverability rule — commands, directory trees, exports, types, config rules, dependency lists.
+
+**Structure:**
+
+- Root `CLAUDE.md` — project-wide context applicable everywhere
+- Service-level `CLAUDE.md` — that module's non-obvious constraints only, never repeat root content
+
+**Size:** target <30 lines. If you're past 50 lines, it's bloated. Cut ruthlessly.
+
+See `references/claude-md-guide.md` for templates and examples.
+
+## README.md Rules
+
+**Purpose:** human onboarding — get someone from zero to productive.
+
+**Content:** project description, prerequisites, setup, how to run, how to test, how to contribute. Keep it executable — commands that copy-paste and work beat prose.
+
+Root `README.md` = full overview + setup. Service-level = purpose + how to run independently. Don't duplicate `CLAUDE.md` content — different audiences, different purposes.
+
+## Grey Box Documentation
+
+Every module is a grey box — clear public API, hidden internals. Documentation describes the **interface** (what it does, constraints, gotchas), NOT the **implementation** (file trees, data flow, internal functions).
+
+Progressive disclosure: import from public API → read docs for context → read source only if needed.
+
+You own the interface. AI owns the implementation. Tests keep it honest. If docs describe internal wiring, they couple consumers to implementation and break on every refactor.
+
+## Document Separation
+
+Each document has exactly one job:
+
+| Document          | Job                     |
+| ----------------- | ----------------------- |
+| `README.md`       | Human onboarding        |
+| `CLAUDE.md`       | AI agent context        |
+| Architecture docs | System design decisions |
+| API docs          | Endpoint contracts      |
+
+Never duplicate between them. If the same info is in two places, delete the copy in the wrong file.
+
+## When Documentation IS Needed
+
+Some things genuinely need docs because no amount of code reading reveals them:
+
+- **"Why" decisions** — architectural rationale, trade-off reasoning
+- **Cross-service contracts** — agreements not enforced by types or schemas
+- **Environment gotchas** — WSL quirks, VPN requirements, OS-specific steps
+- **Historical context** — past decisions constraining current design
+- **Security procedures** — auth flows, key rotation, access patterns
+- **Non-obvious flags** — env vars or CLI flags with surprising behavior
+
+If you're unsure whether something needs docs, apply the three-question test from `references/anti-patterns.md`.
+
+## Deep Dives
+
+| Topic                                                  | Reference                       |
+| ------------------------------------------------------ | ------------------------------- |
+| CLAUDE.md and README templates                         | `references/claude-md-guide.md` |
+| Anti-patterns, bloat examples, the three-question test | `references/anti-patterns.md`   |

--- a/.claude/skills/docs-that-work/references/anti-patterns.md
+++ b/.claude/skills/docs-that-work/references/anti-patterns.md
@@ -1,0 +1,97 @@
+# Documentation Anti-Patterns
+
+How to recognize and avoid documentation bloat.
+
+## Bloated CLAUDE.md: Before & After
+
+### Before (bloated)
+
+```markdown
+# MyApp — A Next.js e-commerce application.
+
+## Directory Structure
+- `src/components/` — React components
+- `src/components/ui/` — Shared UI primitives
+- `src/lib/` — Utility functions
+- `src/hooks/` — Custom React hooks
+- `src/types/` — TypeScript type definitions
+
+## Exports
+- `Button`, `Input`, `Modal` from `components/ui`
+- `useAuth`, `useCart` from `hooks/`
+
+## Types
+- `User` — { id, name, email, role }
+- `Product` — { id, title, price, stock }
+
+## Dependencies
+- next 14.1, react 18, tailwindcss 3.4, prisma 5.8
+
+## Linting
+- ESLint with next/core-web-vitals
+- Prettier with single quotes, no semicolons
+
+## Commands
+- `npm run dev` / `npm run build` / `npm test` / `npm run lint`
+```
+
+### After (correct)
+
+```markdown
+# Purpose
+
+E-commerce storefront. Handles product browsing, cart, and checkout. Payments delegate to the billing service via internal API.
+
+# Conventions
+
+- All pages use the `AppLayout` wrapper — never render a page without it
+- Cart state lives in Zustand store, NOT React context — previous migration was partial, don't reintroduce context
+- Prices are stored as integers (cents) everywhere — never use floats for money
+- `npm run dev` requires `docker compose up db` first
+```
+
+Everything removed was discoverable. Everything kept requires human knowledge.
+
+## Catalog of Discoverable Content
+
+| Pattern | Why It's Discoverable | What an Agent Does Instead |
+|---|---|---|
+| Directory trees | `glob` or `ls` | Scans the filesystem |
+| Exports / public API | Read `index.ts` or `__init__.py` | Reads entry point files |
+| Type definitions | Read source files | Reads the type/interface definitions |
+| Linter rules | Read `.eslintrc`, `ruff.toml`, etc. | Reads config files |
+| Test file locations | `glob` for `*.test.*` or `tests/` | Searches for test patterns |
+| Dependencies | Read `package.json`, `pyproject.toml` | Reads manifest files |
+| Env var names | Read `.env.example` or `.env.template` | Reads env template |
+| Script commands | Read `package.json` scripts or `justfile` | Reads task runner config |
+| CI pipeline steps | Read `.github/workflows/` | Reads CI config |
+
+If it's in a file an agent can read, it doesn't need documentation.
+
+## The Three-Question Test
+
+Before adding any line to documentation, ask:
+
+1. **Could an agent find this by reading a config file?**
+2. **Could an agent find this by reading source code?**
+3. **Could an agent find this by running a standard command?**
+
+If any answer is **yes**, don't write it.
+
+### Examples
+
+- "All tests are in `__tests__/`" → `glob` finds them. **Don't write it.**
+- "Prices are cents (integers), never floats" → no config or code pattern reveals this convention. **Write it.**
+- "We use ESLint with airbnb config" → it's in `.eslintrc`. **Don't write it.**
+
+## Common Mistakes
+
+When asked to "document the project," agents typically:
+
+1. **Dump the init output** — list every file, directory, and config from the project root
+2. **Mirror the filesystem** — reproduce the directory tree as a markdown list
+3. **Copy type definitions** — paste interfaces and types into docs
+4. **Write a novel** — produce 200+ line CLAUDE.md files that no agent will fully process
+5. **Duplicate across files** — put the same commands in README, CLAUDE.md, and CONTRIBUTING.md
+
+Recognize these patterns. When you catch yourself doing any of them, stop and apply the three-question test to every line.

--- a/.claude/skills/docs-that-work/references/claude-md-guide.md
+++ b/.claude/skills/docs-that-work/references/claude-md-guide.md
@@ -1,0 +1,116 @@
+# CLAUDE.md & README Templates
+
+Concrete templates and decision guides for project documentation.
+
+## Root CLAUDE.md Template
+
+```markdown
+# Purpose
+
+[1-2 sentences: what this project does and why it exists]
+
+# Conventions
+
+- [Convention that cannot be discovered from config files]
+- [Gotcha that has bitten people before]
+- [Non-obvious constraint on how modules interact]
+```
+
+### Example: Backend API Service
+
+```markdown
+# Purpose
+
+Order processing API for the warehouse system. Receives orders from the storefront, validates inventory, and dispatches to fulfillment.
+
+# Conventions
+
+- All API responses wrap payload in `{"data": ...}` envelope — no bare objects
+- Never import from `internal/` packages outside their parent module
+- Migration files are manually numbered (not auto-generated) — check latest before creating
+- `just dev` requires local Postgres running first (`just db-up`)
+```
+
+Commands like `just dev`, `just test`, `just lint` are discoverable from the justfile — only the non-obvious prerequisite gotcha is documented.
+
+## Service-Level CLAUDE.md Template
+
+```markdown
+# Purpose
+
+[1 sentence: what this service/module does within the larger system]
+
+# Non-Obvious Context
+
+- [Constraint specific to this module]
+- [Gotcha that only applies here]
+```
+
+### Example: Payment Module
+
+```markdown
+# Purpose
+
+Handles payment processing via Stripe — wraps the Stripe SDK and enforces idempotency.
+
+# Non-Obvious Context
+
+- All Stripe calls must include an idempotency key — the helper in `utils.py` generates one from order ID
+- Webhook signature verification uses a different API key than charge creation (see env vars)
+```
+
+Rule: never repeat root-level content. If it applies project-wide, it goes in root `CLAUDE.md`.
+
+## README.md Template
+
+Structure: title, description, prerequisites, setup, run, test, contribute. Every section should contain commands that copy-paste and work.
+
+```markdown
+# Warehouse API
+
+Order processing API for the warehouse fulfillment system.
+
+## Prerequisites
+
+- Python >= 3.12
+- Docker (for local Postgres)
+
+## Setup
+
+\`\`\`bash
+just install
+just db-up
+\`\`\`
+
+## Run / Test
+
+\`\`\`bash
+just dev # start dev server
+just test # run pytest
+\`\`\`
+
+## Contributing
+
+See [CONTRIBUTING.md](./CONTRIBUTING.md).
+```
+
+## Root vs Service-Level Decision
+
+| If the content...                        | Put it in...                                   |
+| ---------------------------------------- | ---------------------------------------------- |
+| Applies to >1 service or the whole repo  | Root `CLAUDE.md`                               |
+| Is specific to one service/module        | Service-level `CLAUDE.md`                      |
+| Contradicts or narrows a root convention | Service-level `CLAUDE.md` (with explicit note) |
+
+When unsure, put it in root. Easier to push down later than to discover missing context scattered across services.
+
+## What Belongs Where
+
+| Content Type | CLAUDE.md | README | Architecture Doc | Neither (Discoverable) |
+|---|---|---|---|---|
+| Project purpose | 1-2 sentences | Full description | - | - |
+| Setup / run / test commands | - | Yes | - | Discoverable from task runner |
+| Non-obvious gotchas | Yes | - | - | - |
+| Naming conventions | Only if not in linter | - | - | If in linter config |
+| Architecture / API contracts | - | - | Yes | - |
+| Dir trees, types, deps, env names | - | - | - | Always discoverable |

--- a/.claude/skills/gha-diagnosis/SKILL.md
+++ b/.claude/skills/gha-diagnosis/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: gha-diagnosis
+context: fork
+argument-hint: "<run URL, job ID, or leave empty to auto-detect>"
+description: Use when GitHub Actions checks fail, workflow runs are red, or user asks to fix CI. Triggers on "fix CI", "actions failing", "checks are red", "pipeline broke", "workflow failed". User may provide a run URL, job ID, or just ask to fix.
+---
+
+# GitHub Actions — Autonomous Failure Fix Loop
+
+Fetch failed workflow logs via `gh`, diagnose root causes, fix, verify locally, commit. All failures in one pass.
+
+## Input
+
+User may provide:
+- **Nothing** — find failures via `gh run list --status failure --limit 5`
+- **Run URL** — e.g. `https://github.com/org/repo/actions/runs/123` → extract run ID
+- **Run/Job ID** — use directly with `gh run view <id> --log-failed`
+
+## Context Loading
+
+Read `.github/workflows/*.yml` to understand the exact commands each job runs. These are your local verify commands.
+
+## Phase 1: Fetch and Triage
+
+```bash
+gh run view <run-id> --log-failed
+```
+
+Group failures by root cause:
+
+| Category | Signals | Typical Fix |
+|----------|---------|-------------|
+| **Lint/Format** | linter, formatter errors | Auto-fix or targeted edit |
+| **Test** | assertion errors, crashes | Fix code or test |
+| **Security** | vulnerability flags | Upgrade dep, scoped override |
+| **Stale workflow** | action SHA mismatch, deprecated syntax | Update workflow YAML |
+| **Env/secrets** | missing var, auth failure | Fix workflow env block |
+| **Build** | type errors, import failures | Fix source or dependency |
+| **Spec drift** | generated code stale | Regenerate artifacts |
+
+## Phase 2: Fix Loop
+
+Process in dependency order: workflow config → lint → tests → build.
+
+1. **Diagnose** — exact file(s) and line(s) from the log
+2. **Fix** — minimal change
+3. **Verify** — run the same command from the workflow YAML locally
+4. **If fails** — revert, re-read error, try different approach (max 3 attempts)
+5. **Commit** — one per logical fix, conventional commit format
+
+## Phase 3: Push and Confirm
+
+1. Push all fix commits
+2. `gh run list --limit 1 --json status,conclusion,url`
+3. If new failures appear, loop back to Phase 1
+
+## Rules
+
+- Batch all failures — don't fix one and stop
+- Read the actual log — don't guess from job names
+- Verify locally before committing
+- One commit per fix
+- Revert failed attempts — don't stack patches
+- Don't diagnose CI from unpushed local code — push first
+
+## Common Pitfalls
+
+| Pitfall | Instead |
+|---------|---------|
+| Guess fix from job name | Read `gh run view <id> --log-failed` |
+| Blanket dep override | Scope to specific dependency paths |
+| Update action SHA blindly | Check release notes for breaking changes |
+| Fix warnings not in the error | Only fix what CI flagged |
+| `--no-verify` to bypass hooks | Fix the hook issue |

--- a/.claude/skills/typescript-development/SKILL.md
+++ b/.claude/skills/typescript-development/SKILL.md
@@ -1,0 +1,246 @@
+---
+name: typescript-development
+description: This skill should be used when the user asks to "write TypeScript code", "create a TypeScript module", "define TypeScript types", "add type annotations", "use generics", "handle errors in TypeScript", "set up tsconfig", "organize TypeScript project", or when writing any TypeScript code that is not tied to a specific library or framework. Covers type system, strict mode, naming conventions, error handling, async patterns, and project structure.
+version: 0.1.0
+---
+
+# TypeScript Development
+
+This skill covers modern TypeScript best practices for writing clean, type-safe code. It focuses on the language itself — no library or framework specifics. Apply these conventions to all TypeScript code in the project.
+
+## Strict Mode
+
+Always enable `strict: true` in `tsconfig.json`. Never disable individual strict flags. This is non-negotiable — it catches entire categories of bugs at compile time.
+
+Key strict behaviors:
+- `null` and `undefined` are distinct types (no implicit null)
+- Every value must have a known type (no implicit `any`)
+- Catch clause variables are `unknown`, not `any`
+
+## Naming Conventions
+
+| Construct | Convention | Example |
+|---|---|---|
+| Variables, functions | camelCase | `getUserName`, `isActive` |
+| Classes | PascalCase | `UserService`, `HttpClient` |
+| Interfaces | PascalCase (no `I` prefix) | `User`, not `IUser` |
+| Type aliases | PascalCase | `ApiResponse`, `EventMap` |
+| Constants | camelCase or UPPER_SNAKE | `maxRetries` or `MAX_RETRIES` |
+| Enum-like objects | PascalCase key, camelCase/string values | `Status.Active` |
+| Generic parameters | Single uppercase or descriptive | `T`, `TResult`, `K extends keyof T` |
+| File names | kebab-case | `user-service.ts`, `api-client.ts` |
+| Boolean variables | Prefix with `is`, `has`, `can`, `should` | `isValid`, `hasPermission` |
+
+## Type Annotations
+
+### When to annotate explicitly
+
+- Function parameters — always
+- Function return types — always for exported functions, optional for local functions
+- Class properties — always
+- Variables — only when the type cannot be inferred
+
+```typescript
+// Parameters and return: always annotate
+function calculateTotal(items: LineItem[], taxRate: number): number {
+  return items.reduce((sum, item) => sum + item.price, 0) * (1 + taxRate);
+}
+
+// Variable: skip annotation when inferred
+const total = calculateTotal(items, 0.1); // inferred as number
+
+// Variable: annotate when not obvious
+const cache: Map<string, User> = new Map();
+```
+
+### Prefer interfaces for object shapes
+
+```typescript
+// Prefer interface for object shapes
+interface User {
+  id: string;
+  name: string;
+  email: string;
+}
+
+// Use type alias for unions, intersections, mapped types
+type Result<T> = { ok: true; value: T } | { ok: false; error: Error };
+type StringKeys<T> = Extract<keyof T, string>;
+```
+
+### Avoid `any`
+
+Use `unknown` instead of `any` for values of uncertain type. Narrow with type guards before use:
+
+```typescript
+// Bad
+function parse(input: any): string { return input.name; }
+
+// Good
+function parse(input: unknown): string {
+  if (typeof input === "object" && input !== null && "name" in input) {
+    return String((input as { name: unknown }).name);
+  }
+  throw new Error("Invalid input");
+}
+```
+
+**Acceptable uses of `any`:** Only when interfacing with untyped external code and a proper type cannot be defined. Always add a comment explaining why.
+
+## Discriminated Unions
+
+Model state variants with a shared literal discriminant:
+
+```typescript
+type LoadingState<T> =
+  | { status: "idle" }
+  | { status: "loading" }
+  | { status: "success"; data: T }
+  | { status: "error"; error: Error };
+```
+
+Always include an exhaustive check using `never`:
+
+```typescript
+function assertNever(value: never): never {
+  throw new Error(`Unexpected value: ${value}`);
+}
+
+function render<T>(state: LoadingState<T>): string {
+  switch (state.status) {
+    case "idle": return "Ready";
+    case "loading": return "Loading...";
+    case "success": return String(state.data);
+    case "error": return state.error.message;
+    default: return assertNever(state);
+  }
+}
+```
+
+## Error Handling
+
+### Catch unknown errors
+
+```typescript
+try {
+  await riskyOperation();
+} catch (error: unknown) {
+  if (error instanceof AppError) {
+    handleAppError(error);
+  } else if (error instanceof Error) {
+    handleGenericError(error);
+  } else {
+    handleUnknown(String(error));
+  }
+}
+```
+
+### Custom error classes
+
+```typescript
+class AppError extends Error {
+  constructor(
+    message: string,
+    readonly code: string,
+    readonly statusCode: number = 500,
+  ) {
+    super(message);
+    this.name = "AppError";
+  }
+}
+```
+
+### Result type over exceptions
+
+For expected failure paths, prefer a typed `Result` over throwing:
+
+```typescript
+type Result<T, E = Error> =
+  | { ok: true; value: T }
+  | { ok: false; error: E };
+```
+
+## Const Objects Over Enums
+
+Prefer `as const` objects over TypeScript `enum`:
+
+```typescript
+const Status = {
+  Active: "active",
+  Inactive: "inactive",
+  Pending: "pending",
+} as const;
+
+type Status = (typeof Status)[keyof typeof Status];
+```
+
+**Why:** No runtime code emitted, better tree-shaking, interoperates with plain strings.
+
+## Async Code
+
+- Always specify `Promise<T>` return types on async functions
+- Use `Promise.all` for independent concurrent operations
+- Use `Promise.allSettled` when partial failure is acceptable
+- Never use `void` for async function returns — use `Promise<void>`
+
+```typescript
+async function fetchUserData(id: string): Promise<UserData> {
+  const [profile, orders] = await Promise.all([
+    fetchProfile(id),
+    fetchOrders(id),
+  ]);
+  return { profile, orders };
+}
+```
+
+## Immutability
+
+- Use `readonly` on properties that should not change after initialization
+- Use `readonly T[]` (or `ReadonlyArray<T>`) for array parameters that should not be mutated
+- Use `as const` for literal objects and arrays that should be fully immutable
+- Prefer spreading over mutation: `{ ...obj, key: newValue }` over `obj.key = newValue`
+
+## Type-Only Imports
+
+Use `import type` for imports used only as types:
+
+```typescript
+import type { User } from "./models.js";
+import { createUser } from "./models.js";
+```
+
+This prevents circular dependency issues and ensures types are erased at compile time.
+
+## ESM Import Rule
+
+When using `"type": "module"` in `package.json` with `"module": "Node16"`, all relative imports must include the `.js` extension — even in `.ts` source files:
+
+```typescript
+import { helper } from "./utils.js";   // Correct
+import { helper } from "./utils";      // Wrong — fails at runtime
+```
+
+## Quick Reference: Common Mistakes
+
+| Mistake | Fix |
+|---|---|
+| Using `any` | Use `unknown` and narrow with type guards |
+| Missing return type on exports | Add explicit return type annotation |
+| `enum` for string constants | Use `as const` object + derived union type |
+| Mutable function parameters | Mark arrays/objects as `readonly` |
+| Bare `catch (error)` | Use `catch (error: unknown)` and narrow |
+| Missing `.js` in ESM imports | Add `.js` extension to all relative imports |
+| `strict: false` in tsconfig | Always use `strict: true` |
+| `I` prefix on interfaces | Drop the prefix: `User`, not `IUser` |
+| Optional props for distinct states | Use discriminated unions |
+| Type assertions (`as T`) | Prefer type guards and narrowing |
+
+## Additional Resources
+
+### Reference Files
+
+For detailed type system features and advanced patterns, consult:
+- **`references/type-system.md`** — Generics, utility types, conditional types, mapped types, template literal types, type guards, discriminated unions, branded types, satisfies operator, const assertions, declaration merging
+- **`references/patterns.md`** — Immutability patterns, error handling (Result type, custom errors), async patterns (generators, concurrency), builder pattern, type-safe event emitter, overloaded functions, module patterns, enum alternatives, assertion functions, narrowing patterns
+- **`references/type-inference.md`** — Variable inference, function return inference, generic inference, contextual typing, satisfies operator, infer keyword, control flow analysis, type guards, narrowing patterns, best practices for when to annotate vs let inference work
+- **`references/project-structure.md`** — tsconfig.json essentials (strict mode flags, module config, safety flags), ESM/CJS setup, directory layout, organizing types, barrel exports, declaration files, import organization, path aliases, gitignore

--- a/.claude/skills/typescript-development/references/patterns.md
+++ b/.claude/skills/typescript-development/references/patterns.md
@@ -1,0 +1,432 @@
+# TypeScript Patterns Reference
+
+## Immutability Patterns
+
+### Readonly properties
+
+```typescript
+interface Config {
+  readonly host: string;
+  readonly port: number;
+}
+
+// Deep readonly
+type DeepReadonly<T> = {
+  readonly [K in keyof T]: T[K] extends object ? DeepReadonly<T[K]> : T[K];
+};
+```
+
+### Readonly arrays and tuples
+
+```typescript
+function processItems(items: readonly string[]): void {
+  // items.push("new"); // Error: push does not exist on readonly string[]
+  const copy = [...items, "new"]; // OK — creates new array
+}
+
+// ReadonlyArray<T> is equivalent to readonly T[]
+function sum(numbers: ReadonlyArray<number>): number {
+  return numbers.reduce((acc, n) => acc + n, 0);
+}
+```
+
+### Frozen objects
+
+```typescript
+const DEFAULTS = Object.freeze({
+  timeout: 5000,
+  retries: 3,
+  baseUrl: "http://localhost",
+} as const);
+```
+
+## Error Handling Patterns
+
+### Typed error classes
+
+```typescript
+class AppError extends Error {
+  constructor(
+    message: string,
+    readonly code: string,
+    readonly statusCode: number = 500,
+  ) {
+    super(message);
+    this.name = "AppError";
+  }
+}
+
+class NotFoundError extends AppError {
+  constructor(resource: string, id: string) {
+    super(`${resource} with id ${id} not found`, "NOT_FOUND", 404);
+    this.name = "NotFoundError";
+  }
+}
+
+class ValidationError extends AppError {
+  constructor(
+    message: string,
+    readonly fields: Record<string, string>,
+  ) {
+    super(message, "VALIDATION_ERROR", 400);
+    this.name = "ValidationError";
+  }
+}
+```
+
+### Result type pattern
+
+Represent success/failure without exceptions:
+
+```typescript
+type Result<T, E = Error> =
+  | { ok: true; value: T }
+  | { ok: false; error: E };
+
+function ok<T>(value: T): Result<T, never> {
+  return { ok: true, value };
+}
+
+function err<E>(error: E): Result<never, E> {
+  return { ok: false, error };
+}
+
+// Usage
+function parsePort(input: string): Result<number, string> {
+  const port = parseInt(input, 10);
+  if (isNaN(port) || port < 0 || port > 65535) {
+    return err(`Invalid port: ${input}`);
+  }
+  return ok(port);
+}
+
+const result = parsePort("8080");
+if (result.ok) {
+  console.log(result.value); // number
+} else {
+  console.error(result.error); // string
+}
+```
+
+### Unknown in catch blocks
+
+```typescript
+try {
+  riskyOperation();
+} catch (error: unknown) {
+  if (error instanceof AppError) {
+    handleAppError(error);
+  } else if (error instanceof Error) {
+    handleGenericError(error);
+  } else {
+    handleUnknown(String(error));
+  }
+}
+```
+
+## Async Patterns
+
+### Async function signatures
+
+```typescript
+async function fetchData(id: string): Promise<Data> {
+  const response = await fetch(`/api/data/${id}`);
+  if (!response.ok) {
+    throw new AppError("Fetch failed", "FETCH_ERROR", response.status);
+  }
+  return response.json() as Promise<Data>;
+}
+```
+
+### Concurrent operations
+
+```typescript
+// Run in parallel, fail if any fails
+const [users, orders] = await Promise.all([
+  fetchUsers(),
+  fetchOrders(),
+]);
+
+// Run in parallel, get individual results
+const results = await Promise.allSettled([
+  fetchUsers(),
+  fetchOrders(),
+]);
+
+for (const result of results) {
+  if (result.status === "fulfilled") {
+    process(result.value);
+  } else {
+    logError(result.reason);
+  }
+}
+```
+
+### Typed async iterators
+
+```typescript
+async function* paginate<T>(
+  fetcher: (page: number) => Promise<T[]>,
+): AsyncGenerator<T[], void, undefined> {
+  let page = 0;
+  while (true) {
+    const items = await fetcher(page);
+    if (items.length === 0) break;
+    yield items;
+    page++;
+  }
+}
+
+// Usage
+for await (const batch of paginate(fetchUserPage)) {
+  processBatch(batch);
+}
+```
+
+## Builder Pattern
+
+```typescript
+class QueryBuilder<T> {
+  private filters: Array<(item: T) => boolean> = [];
+  private sortKey?: keyof T;
+  private sortOrder: "asc" | "desc" = "asc";
+  private limitCount?: number;
+
+  where(predicate: (item: T) => boolean): this {
+    this.filters.push(predicate);
+    return this;
+  }
+
+  orderBy(key: keyof T, order: "asc" | "desc" = "asc"): this {
+    this.sortKey = key;
+    this.sortOrder = order;
+    return this;
+  }
+
+  limit(count: number): this {
+    this.limitCount = count;
+    return this;
+  }
+
+  execute(items: T[]): T[] {
+    let result = items.filter((item) =>
+      this.filters.every((f) => f(item)),
+    );
+
+    if (this.sortKey !== undefined) {
+      const key = this.sortKey;
+      const dir = this.sortOrder === "asc" ? 1 : -1;
+      result.sort((a, b) => (a[key] > b[key] ? dir : -dir));
+    }
+
+    if (this.limitCount !== undefined) {
+      result = result.slice(0, this.limitCount);
+    }
+
+    return result;
+  }
+}
+```
+
+## Type-Safe Event Emitter
+
+```typescript
+type EventMap = Record<string, unknown[]>;
+
+class TypedEmitter<Events extends EventMap> {
+  private listeners = new Map<keyof Events, Set<Function>>();
+
+  on<K extends keyof Events>(
+    event: K,
+    handler: (...args: Events[K]) => void,
+  ): void {
+    if (!this.listeners.has(event)) {
+      this.listeners.set(event, new Set());
+    }
+    this.listeners.get(event)!.add(handler);
+  }
+
+  emit<K extends keyof Events>(event: K, ...args: Events[K]): void {
+    const handlers = this.listeners.get(event);
+    if (handlers) {
+      for (const handler of handlers) {
+        handler(...args);
+      }
+    }
+  }
+
+  off<K extends keyof Events>(
+    event: K,
+    handler: (...args: Events[K]) => void,
+  ): void {
+    this.listeners.get(event)?.delete(handler);
+  }
+}
+
+// Usage
+interface AppEvents extends EventMap {
+  userLogin: [userId: string, timestamp: number];
+  error: [error: Error];
+  shutdown: [];
+}
+
+const emitter = new TypedEmitter<AppEvents>();
+emitter.on("userLogin", (userId, timestamp) => { /* ... */ });
+emitter.emit("userLogin", "u-123", Date.now());
+```
+
+## Overloaded Functions
+
+Use function overloads when the return type depends on the input:
+
+```typescript
+function parse(input: string, asNumber: true): number;
+function parse(input: string, asNumber: false): string;
+function parse(input: string, asNumber: boolean): number | string {
+  return asNumber ? Number(input) : input;
+}
+
+const num = parse("42", true);    // number
+const str = parse("42", false);   // string
+```
+
+### Method overloads in classes
+
+```typescript
+class Formatter {
+  format(value: string): string;
+  format(value: number): string;
+  format(value: Date): string;
+  format(value: string | number | Date): string {
+    if (typeof value === "string") return value.trim();
+    if (typeof value === "number") return value.toFixed(2);
+    return value.toISOString();
+  }
+}
+```
+
+## Module Patterns
+
+### Namespace-like modules
+
+```typescript
+// math/index.ts — re-export as a namespace-like module
+export { add, subtract } from "./arithmetic.js";
+export { sin, cos, tan } from "./trigonometry.js";
+export { PI, E } from "./constants.js";
+```
+
+### Lazy initialization
+
+```typescript
+let cachedConnection: Connection | undefined;
+
+export function getConnection(): Connection {
+  cachedConnection ??= createConnection();
+  return cachedConnection;
+}
+```
+
+### Type-only exports
+
+```typescript
+// Ensure types are erased at runtime — no accidental runtime imports
+export type { User, Order, Product } from "./models.js";
+export { UserSchema } from "./models.js";
+```
+
+## Enum Alternatives
+
+### Const objects over enums
+
+Prefer const objects with `as const` over TypeScript `enum`:
+
+```typescript
+// Prefer this
+const Status = {
+  Active: "active",
+  Inactive: "inactive",
+  Pending: "pending",
+} as const;
+
+type Status = (typeof Status)[keyof typeof Status];
+// "active" | "inactive" | "pending"
+
+// Over this
+enum StatusEnum {
+  Active = "active",
+  Inactive = "inactive",
+  Pending = "pending",
+}
+```
+
+**Why:** Const objects produce no runtime code, support tree-shaking, and interoperate better with plain strings. Enums create runtime objects and have quirks with reverse mappings.
+
+### Union types for simple cases
+
+```typescript
+type Direction = "north" | "south" | "east" | "west";
+type LogLevel = "debug" | "info" | "warn" | "error";
+```
+
+## Assertion Functions
+
+```typescript
+function assertDefined<T>(
+  value: T | null | undefined,
+  name: string,
+): asserts value is T {
+  if (value === null || value === undefined) {
+    throw new Error(`Expected ${name} to be defined, got ${value}`);
+  }
+}
+
+function assertNever(value: never, message?: string): never {
+  throw new Error(message ?? `Unexpected value: ${value}`);
+}
+
+// Usage — exhaustive switch
+function handleStatus(status: Status): string {
+  switch (status) {
+    case "active": return "Active";
+    case "inactive": return "Inactive";
+    case "pending": return "Pending";
+    default: assertNever(status);
+  }
+}
+```
+
+## Narrowing Patterns
+
+### In operator narrowing
+
+```typescript
+interface Fish { swim(): void }
+interface Bird { fly(): void }
+
+function move(animal: Fish | Bird): void {
+  if ("swim" in animal) {
+    animal.swim(); // narrowed to Fish
+  } else {
+    animal.fly(); // narrowed to Bird
+  }
+}
+```
+
+### Truthiness narrowing
+
+```typescript
+function printName(name: string | null | undefined): void {
+  if (name) {
+    console.log(name.toUpperCase()); // narrowed to string
+  }
+}
+```
+
+### Array.isArray narrowing
+
+```typescript
+function normalize(input: string | string[]): string[] {
+  return Array.isArray(input) ? input : [input];
+}
+```

--- a/.claude/skills/typescript-development/references/project-structure.md
+++ b/.claude/skills/typescript-development/references/project-structure.md
@@ -1,0 +1,303 @@
+# TypeScript Project Structure Reference
+
+## tsconfig.json Essentials
+
+### Strict mode (non-negotiable)
+
+```json
+{
+  "compilerOptions": {
+    "strict": true
+  }
+}
+```
+
+`strict: true` enables all strict checks at once:
+
+| Flag | What it enforces |
+|---|---|
+| `strictNullChecks` | `null` and `undefined` are distinct types |
+| `noImplicitAny` | Every value must have a known type |
+| `strictFunctionTypes` | Contravariant function parameter checks |
+| `strictBindCallApply` | Type-safe `bind`, `call`, `apply` |
+| `strictPropertyInitialization` | Class properties must be initialized |
+| `noImplicitThis` | `this` must have an explicit type |
+| `useUnknownInCatchVariables` | Catch clause variables are `unknown` |
+| `alwaysStrict` | Emit `"use strict"` in every file |
+
+### Recommended base configuration
+
+```json
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}
+```
+
+### Additional safety flags
+
+```json
+{
+  "compilerOptions": {
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitOverride": true
+  }
+}
+```
+
+| Flag | Effect |
+|---|---|
+| `noUncheckedIndexedAccess` | Array/record indexing returns `T \| undefined` |
+| `exactOptionalPropertyTypes` | `undefined` not assignable to optional props unless explicit |
+| `noImplicitReturns` | Every code path must return |
+| `noFallthroughCasesInSwitch` | Switch cases must break/return |
+| `noImplicitOverride` | Require `override` keyword on overridden methods |
+
+## Module Configuration
+
+### ESM setup (type: "module")
+
+In `package.json`:
+```json
+{
+  "type": "module"
+}
+```
+
+In `tsconfig.json`:
+```json
+{
+  "compilerOptions": {
+    "module": "Node16",
+    "moduleResolution": "Node16"
+  }
+}
+```
+
+**Critical rule:** All relative imports must include the `.js` extension (even in `.ts` source):
+
+```typescript
+// Correct
+import { helper } from "./utils.js";
+
+// Wrong — fails at runtime with ESM
+import { helper } from "./utils";
+```
+
+### CJS setup (legacy)
+
+```json
+{
+  "compilerOptions": {
+    "module": "CommonJS",
+    "moduleResolution": "Node10"
+  }
+}
+```
+
+No extension required for relative imports in CJS mode.
+
+## Directory Layout
+
+### Standard project layout
+
+```
+project/
+├── src/
+│   ├── index.ts              # public API / entry point
+│   ├── types.ts              # shared type definitions
+│   ├── errors.ts             # custom error classes
+│   ├── config.ts             # configuration loading
+│   ├── domain/               # core business logic
+│   │   ├── models.ts
+│   │   └── services.ts
+│   └── utils/                # pure utility functions
+│       ├── strings.ts
+│       └── validation.ts
+├── dist/                     # compiled output (gitignored)
+├── package.json
+├── tsconfig.json
+└── .gitignore
+```
+
+### Organizing types
+
+**Collocated types (preferred):** Define types alongside the code that uses them:
+
+```typescript
+// domain/user.ts
+export interface User {
+  id: string;
+  name: string;
+  email: string;
+}
+
+export function createUser(name: string, email: string): User {
+  return { id: generateId(), name, email };
+}
+```
+
+**Shared types file:** Only extract to a separate `types.ts` when a type is used across multiple modules:
+
+```typescript
+// types.ts — only types shared by 3+ modules
+export interface Timestamped {
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export type Id = string;
+```
+
+### Barrel exports
+
+Use `index.ts` files to create clean public APIs:
+
+```typescript
+// domain/index.ts
+export { User, createUser } from "./user.js";
+export { Order, createOrder } from "./order.js";
+export type { UserFilter } from "./user.js";
+```
+
+**Guidelines for barrel exports:**
+- Use barrel files at module boundaries (one level deep)
+- Avoid deep nesting of barrel files (re-exporting from re-exports)
+- Use `export type` for type-only re-exports
+
+## Declaration Files
+
+### When to emit declarations
+
+Set `declaration: true` when the package is consumed by other TypeScript code (libraries, shared packages):
+
+```json
+{
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true
+  }
+}
+```
+
+`declarationMap: true` enables "go to source" in editors, pointing to `.ts` instead of `.d.ts`.
+
+### Custom type declarations
+
+For untyped modules or global augmentation:
+
+```typescript
+// src/types/global.d.ts
+declare module "untyped-module" {
+  export function doSomething(input: string): Promise<void>;
+}
+
+// Augment global scope
+declare global {
+  interface Window {
+    appConfig: AppConfig;
+  }
+}
+```
+
+Place custom declarations in `src/types/` and ensure the directory is included in `tsconfig.json`'s `include`.
+
+## Import Organization
+
+### Recommended import order
+
+1. Built-in Node.js modules
+2. External dependencies (from `node_modules`)
+3. Internal absolute imports (aliases)
+4. Relative imports
+
+```typescript
+// 1. Built-in
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+// 2. External (blank line separator)
+import { externalHelper } from "external-lib";
+
+// 3. Internal / aliased (blank line separator)
+import { db } from "@/database.js";
+
+// 4. Relative (blank line separator)
+import { User } from "./models.js";
+import { validate } from "./validation.js";
+```
+
+### Type-only imports
+
+Use `import type` to ensure types are erased at compile time:
+
+```typescript
+import type { User, Order } from "./models.js";
+import { createUser } from "./models.js";
+
+// Or inline
+import { createUser, type User } from "./models.js";
+```
+
+**When to use `import type`:**
+- Importing interfaces, type aliases, or enums used only as types
+- Prevents circular dependency issues at runtime
+- Enforced with `"verbatimModuleSyntax": true` in tsconfig
+
+## Path Aliases
+
+### Setting up aliases
+
+In `tsconfig.json`:
+```json
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  }
+}
+```
+
+**Note:** Path aliases are a compile-time feature only. The runtime environment (Node.js) does not resolve them. A bundler or path-rewriting tool is required for runtime resolution.
+
+## Gitignore for TypeScript Projects
+
+```gitignore
+# Compiled output
+dist/
+
+# Dependencies
+node_modules/
+
+# TypeScript cache
+*.tsbuildinfo
+
+# Environment
+.env
+.env.local
+
+# OS files
+.DS_Store
+Thumbs.db
+```

--- a/.claude/skills/typescript-development/references/type-inference.md
+++ b/.claude/skills/typescript-development/references/type-inference.md
@@ -1,0 +1,351 @@
+# TypeScript Type Inference Reference
+
+Patterns for leveraging TypeScript's type inference capabilities.
+
+## Basic Inference
+
+### Variable Inference
+
+```typescript
+// TypeScript infers types from initialization
+const name = 'John'          // type: string
+const age = 30               // type: number
+const isActive = true        // type: boolean
+const items = [1, 2, 3]      // type: number[]
+
+// Literal types with const
+let status = 'active'        // type: string
+const mode = 'dark' as const // type: 'dark'
+
+// Object inference
+const user = {
+  name: 'John',
+  age: 30,
+}  // type: { name: string; age: number }
+
+// const assertion for readonly literal object
+const config = {
+  api: '/api/v1',
+  timeout: 5000,
+} as const
+// type: { readonly api: "/api/v1"; readonly timeout: 5000 }
+```
+
+### Function Return Inference
+
+```typescript
+// Return type inferred from return statements
+function add(a: number, b: number) {
+  return a + b  // return type: number
+}
+
+function getUser(id: string) {
+  return { id, name: 'John', active: true }
+}  // return type: { id: string; name: string; active: boolean }
+
+// Async function inference
+async function fetchData() {
+  const response = await fetch('/api/data')
+  return response.json() as Promise<Data>
+}  // return type: Promise<Data>
+```
+
+### Generic Inference
+
+```typescript
+// Type parameter inferred from argument
+function identity<T>(value: T): T {
+  return value
+}
+
+const str = identity('hello')  // T inferred as string
+const num = identity(42)       // T inferred as number
+
+// Multiple type parameters
+function pair<T, U>(first: T, second: U) {
+  return [first, second] as const
+}
+
+const result = pair('name', 42)  // [T, U] inferred as [string, number]
+```
+
+## Contextual Typing
+
+### Callback Parameters
+
+```typescript
+// Parameter types inferred from context
+const numbers = [1, 2, 3, 4, 5]
+
+// 'num' inferred as number from array type
+const doubled = numbers.map(num => num * 2)
+
+// Event handler inference
+document.addEventListener('click', event => {
+  // 'event' inferred as MouseEvent
+  console.log(event.clientX, event.clientY)
+})
+
+// Object method inference
+const handlers = {
+  onClick: (event) => {
+    // Without annotation, event is 'any' - context not available
+  },
+}
+
+// With explicit interface
+interface Handlers {
+  onClick: (event: MouseEvent) => void
+}
+
+const typedHandlers: Handlers = {
+  onClick: (event) => {
+    // 'event' now inferred as MouseEvent
+    console.log(event.button)
+  },
+}
+```
+
+### Satisfies Operator
+
+```typescript
+// 'satisfies' checks type while preserving inferred literal types
+const palette = {
+  red: [255, 0, 0],
+  green: '#00ff00',
+  blue: [0, 0, 255],
+} satisfies Record<string, string | [number, number, number]>
+
+// Type is preserved as literal
+palette.red   // [number, number, number], not string | [number, number, number]
+palette.green // string
+
+// vs type annotation which would widen
+const palette2: Record<string, string | [number, number, number]> = {
+  red: [255, 0, 0],
+  green: '#00ff00',
+  blue: [0, 0, 255],
+}
+palette2.red  // string | [number, number, number] - lost specificity
+```
+
+## Infer Keyword
+
+### Extract Nested Types
+
+```typescript
+// Extract element type from array
+type ElementType<T> = T extends (infer E)[] ? E : never
+
+type StringElement = ElementType<string[]>  // string
+type NumberElement = ElementType<number[]>  // number
+
+// Extract return type
+type ReturnOf<T> = T extends (...args: any[]) => infer R ? R : never
+
+type FnReturn = ReturnOf<() => string>  // string
+
+// Extract Promise value
+type UnwrapPromise<T> = T extends Promise<infer U> ? U : T
+
+type PromiseValue = UnwrapPromise<Promise<string>>  // string
+```
+
+### Complex Infer Patterns
+
+```typescript
+// Extract first element of tuple
+type First<T> = T extends [infer F, ...any[]] ? F : never
+
+type FirstElement = First<[string, number, boolean]>  // string
+
+// Extract last element
+type Last<T> = T extends [...any[], infer L] ? L : never
+
+type LastElement = Last<[string, number, boolean]>  // boolean
+
+// Extract function parameter at specific index
+type ParamAt<T, N extends number> = T extends (...args: infer P) => any
+  ? P[N]
+  : never
+
+type SecondParam = ParamAt<(a: string, b: number) => void, 1>  // number
+```
+
+### Infer in Template Literals
+
+```typescript
+// Extract parts from string literal
+type ExtractRoute<T> = T extends `/${infer Resource}/${infer Id}`
+  ? { resource: Resource; id: Id }
+  : never
+
+type Route = ExtractRoute<'/users/123'>
+// { resource: 'users'; id: '123' }
+
+// Parse event names
+type ParseEvent<T> = T extends `on${infer Event}`
+  ? Uncapitalize<Event>
+  : never
+
+type EventName = ParseEvent<'onClick'>  // 'click'
+```
+
+## Control Flow Analysis
+
+### Narrowing
+
+```typescript
+function process(value: string | number) {
+  if (typeof value === 'string') {
+    // TypeScript knows value is string here
+    return value.toUpperCase()
+  }
+  // TypeScript knows value is number here
+  return value.toFixed(2)
+}
+
+// Truthiness narrowing
+function log(value: string | null | undefined) {
+  if (value) {
+    // value is string (truthy check eliminates null/undefined)
+    console.log(value.length)
+  }
+}
+
+// Equality narrowing
+function compare(a: string | number, b: string | boolean) {
+  if (a === b) {
+    // Both a and b are string (only common type)
+    return a.toUpperCase()
+  }
+}
+```
+
+### Type Guards
+
+```typescript
+interface Dog {
+  bark(): void
+}
+
+interface Cat {
+  meow(): void
+}
+
+// Type predicate
+function isDog(animal: Dog | Cat): animal is Dog {
+  return 'bark' in animal
+}
+
+function makeSound(animal: Dog | Cat) {
+  if (isDog(animal)) {
+    animal.bark()  // TypeScript knows it's Dog
+  } else {
+    animal.meow()  // TypeScript knows it's Cat
+  }
+}
+
+// Assertion function
+function assertString(value: unknown): asserts value is string {
+  if (typeof value !== 'string') {
+    throw new Error('Not a string')
+  }
+}
+
+function process(value: unknown) {
+  assertString(value)
+  // TypeScript knows value is string after assertion
+  console.log(value.toUpperCase())
+}
+```
+
+### Discriminated Unions
+
+```typescript
+type Result<T> =
+  | { success: true; data: T }
+  | { success: false; error: Error }
+
+function handle<T>(result: Result<T>) {
+  if (result.success) {
+    // TypeScript knows result has 'data' property
+    console.log(result.data)
+  } else {
+    // TypeScript knows result has 'error' property
+    console.log(result.error.message)
+  }
+}
+```
+
+## Best Practices
+
+### Let Inference Work
+
+```typescript
+// Bad: Redundant type annotation
+const name: string = 'John'
+const numbers: number[] = [1, 2, 3]
+
+// Good: Let inference do its job
+const name = 'John'
+const numbers = [1, 2, 3]
+```
+
+### Annotate When Needed
+
+```typescript
+// Good: Annotate function parameters
+function greet(name: string): void {
+  console.log(`Hello, ${name}`)
+}
+
+// Good: Annotate when inference would be too wide
+const status: 'active' | 'inactive' = 'active'
+
+// Good: Annotate complex returns
+interface User {
+  id: string
+  name: string
+}
+
+function parseUser(json: string): User {
+  return JSON.parse(json)
+}
+```
+
+### Use typeof for Runtime Values
+
+```typescript
+const config = {
+  api: '/api',
+  timeout: 5000,
+}
+
+// Derive type from runtime value
+type Config = typeof config
+
+function updateConfig(updates: Partial<Config>): void {
+  Object.assign(config, updates)
+}
+```
+
+### Use ReturnType for Function Types
+
+```typescript
+function createUser(name: string, email: string) {
+  return {
+    id: crypto.randomUUID(),
+    name,
+    email,
+    createdAt: new Date(),
+  }
+}
+
+// Derive User type from function
+type User = ReturnType<typeof createUser>
+
+function displayUser(user: User): void {
+  console.log(`${user.name} (${user.email})`)
+}
+```

--- a/.claude/skills/typescript-development/references/type-system.md
+++ b/.claude/skills/typescript-development/references/type-system.md
@@ -1,0 +1,396 @@
+# TypeScript Type System Reference
+
+## Generics
+
+### Basic generics
+
+```typescript
+function identity<T>(value: T): T {
+  return value;
+}
+
+function first<T>(items: T[]): T | undefined {
+  return items[0];
+}
+```
+
+### Constrained generics
+
+```typescript
+function getProperty<T, K extends keyof T>(obj: T, key: K): T[K] {
+  return obj[key];
+}
+
+function merge<T extends object, U extends object>(a: T, b: U): T & U {
+  return { ...a, ...b };
+}
+```
+
+### Generic interfaces and types
+
+```typescript
+interface Repository<T> {
+  findById(id: string): Promise<T | null>;
+  findAll(): Promise<T[]>;
+  save(entity: T): Promise<T>;
+  delete(id: string): Promise<void>;
+}
+
+type Wrapper<T> = {
+  value: T;
+  timestamp: number;
+};
+```
+
+### Generic defaults
+
+```typescript
+interface PaginatedResult<T, M = Record<string, unknown>> {
+  items: T[];
+  total: number;
+  meta: M;
+}
+
+// M defaults to Record<string, unknown> when not specified
+const result: PaginatedResult<User> = { items: [], total: 0, meta: {} };
+```
+
+## Utility Types
+
+### Built-in utility types
+
+| Type | Description | Example |
+|---|---|---|
+| `Partial<T>` | All properties optional | `Partial<User>` for update payloads |
+| `Required<T>` | All properties required | `Required<Config>` for validated config |
+| `Readonly<T>` | All properties readonly | `Readonly<State>` for immutable state |
+| `Pick<T, K>` | Subset of properties | `Pick<User, "id" \| "name">` |
+| `Omit<T, K>` | Exclude properties | `Omit<User, "password">` |
+| `Record<K, V>` | Object with key type K and value type V | `Record<string, number>` |
+| `Extract<T, U>` | Members of T assignable to U | `Extract<Status, "active" \| "pending">` |
+| `Exclude<T, U>` | Members of T not assignable to U | `Exclude<Status, "deleted">` |
+| `NonNullable<T>` | Remove null and undefined | `NonNullable<string \| null>` → `string` |
+| `ReturnType<T>` | Return type of function | `ReturnType<typeof fetchUser>` |
+| `Parameters<T>` | Parameter types as tuple | `Parameters<typeof fetchUser>` |
+| `Awaited<T>` | Unwrap Promise type | `Awaited<Promise<User>>` → `User` |
+
+### Combining utility types
+
+```typescript
+// Update payload: all fields optional except id
+type UpdateUser = Partial<Omit<User, "id">> & Pick<User, "id">;
+
+// Create payload: everything except auto-generated fields
+type CreateUser = Omit<User, "id" | "createdAt" | "updatedAt">;
+
+// Public-safe user: no sensitive fields
+type PublicUser = Omit<User, "password" | "email">;
+```
+
+## Conditional Types
+
+### Basic conditional types
+
+```typescript
+type IsString<T> = T extends string ? true : false;
+
+type StringOrNumber<T> = T extends string ? string : number;
+```
+
+### Inferring within conditional types
+
+```typescript
+type ElementType<T> = T extends (infer E)[] ? E : T;
+// ElementType<string[]> → string
+// ElementType<number>   → number
+
+type UnwrapPromise<T> = T extends Promise<infer U> ? U : T;
+// UnwrapPromise<Promise<string>> → string
+
+type FunctionReturn<T> = T extends (...args: unknown[]) => infer R ? R : never;
+```
+
+### Distributive conditional types
+
+```typescript
+type ToArray<T> = T extends unknown ? T[] : never;
+// ToArray<string | number> → string[] | number[]
+
+// Prevent distribution with tuple wrapper
+type ToArrayNonDist<T> = [T] extends [unknown] ? T[] : never;
+// ToArrayNonDist<string | number> → (string | number)[]
+```
+
+## Mapped Types
+
+### Basic mapped types
+
+```typescript
+type Optional<T> = {
+  [K in keyof T]?: T[K];
+};
+
+type Immutable<T> = {
+  readonly [K in keyof T]: T[K];
+};
+
+type Nullable<T> = {
+  [K in keyof T]: T[K] | null;
+};
+```
+
+### Key remapping (as clause)
+
+```typescript
+type Getters<T> = {
+  [K in keyof T as `get${Capitalize<string & K>}`]: () => T[K];
+};
+
+// Getters<{ name: string; age: number }>
+// → { getName: () => string; getAge: () => number }
+
+type EventHandlers<T> = {
+  [K in keyof T as `on${Capitalize<string & K>}Change`]: (value: T[K]) => void;
+};
+```
+
+### Filtering keys
+
+```typescript
+type StringKeysOnly<T> = {
+  [K in keyof T as T[K] extends string ? K : never]: T[K];
+};
+```
+
+## Template Literal Types
+
+### Basic template literals
+
+```typescript
+type EventName = `${"click" | "focus" | "blur"}Event`;
+// "clickEvent" | "focusEvent" | "blurEvent"
+
+type HttpMethod = "GET" | "POST" | "PUT" | "DELETE";
+type ApiRoute = `/api/${string}`;
+type Endpoint = `${HttpMethod} ${ApiRoute}`;
+```
+
+### With intrinsic string types
+
+```typescript
+type UpperEvent = Uppercase<"click" | "submit">;
+// "CLICK" | "SUBMIT"
+
+type CamelToSnake<S extends string> =
+  S extends `${infer Head}${infer Tail}`
+    ? Tail extends Uncapitalize<Tail>
+      ? `${Lowercase<Head>}${CamelToSnake<Tail>}`
+      : `${Lowercase<Head>}_${CamelToSnake<Tail>}`
+    : S;
+```
+
+## Type Guards
+
+### typeof guards
+
+```typescript
+function processValue(value: string | number): string {
+  if (typeof value === "string") {
+    return value.toUpperCase(); // narrowed to string
+  }
+  return value.toFixed(2); // narrowed to number
+}
+```
+
+### instanceof guards
+
+```typescript
+function handleError(error: unknown): string {
+  if (error instanceof TypeError) {
+    return `Type error: ${error.message}`;
+  }
+  if (error instanceof RangeError) {
+    return `Range error: ${error.message}`;
+  }
+  return "Unknown error";
+}
+```
+
+### Custom type guard functions
+
+```typescript
+interface Dog {
+  kind: "dog";
+  bark(): void;
+}
+
+interface Cat {
+  kind: "cat";
+  purr(): void;
+}
+
+function isDog(animal: Dog | Cat): animal is Dog {
+  return animal.kind === "dog";
+}
+
+// Assertion function — throws if condition not met
+function assertNonNull<T>(value: T | null | undefined, name: string): asserts value is T {
+  if (value === null || value === undefined) {
+    throw new Error(`Expected ${name} to be defined`);
+  }
+}
+```
+
+### Discriminated unions with type guards
+
+```typescript
+type Shape =
+  | { kind: "circle"; radius: number }
+  | { kind: "rectangle"; width: number; height: number }
+  | { kind: "triangle"; base: number; height: number };
+
+function area(shape: Shape): number {
+  switch (shape.kind) {
+    case "circle":
+      return Math.PI * shape.radius ** 2;
+    case "rectangle":
+      return shape.width * shape.height;
+    case "triangle":
+      return (shape.base * shape.height) / 2;
+  }
+}
+```
+
+## Discriminated Unions
+
+### Pattern
+
+Every member shares a literal `kind` (or `type`, `tag`) property:
+
+```typescript
+type Result<T, E = Error> =
+  | { ok: true; value: T }
+  | { ok: false; error: E };
+
+function processResult<T>(result: Result<T>): T {
+  if (result.ok) {
+    return result.value; // narrowed to { ok: true; value: T }
+  }
+  throw result.error; // narrowed to { ok: false; error: Error }
+}
+```
+
+### Exhaustive matching
+
+```typescript
+type Action =
+  | { type: "increment"; amount: number }
+  | { type: "decrement"; amount: number }
+  | { type: "reset" };
+
+function reduce(state: number, action: Action): number {
+  switch (action.type) {
+    case "increment":
+      return state + action.amount;
+    case "decrement":
+      return state - action.amount;
+    case "reset":
+      return 0;
+    default: {
+      const _exhaustive: never = action;
+      return _exhaustive;
+    }
+  }
+}
+```
+
+## Branded Types
+
+Prevent accidental mixing of structurally identical types:
+
+```typescript
+type Brand<T, B extends string> = T & { readonly __brand: B };
+
+type UserId = Brand<string, "UserId">;
+type OrderId = Brand<string, "OrderId">;
+
+function createUserId(id: string): UserId {
+  return id as UserId;
+}
+
+function createOrderId(id: string): OrderId {
+  return id as OrderId;
+}
+
+function fetchUser(id: UserId): Promise<User> { /* ... */ }
+
+const userId = createUserId("u-123");
+const orderId = createOrderId("o-456");
+
+fetchUser(userId);   // OK
+// fetchUser(orderId); // Error: OrderId not assignable to UserId
+```
+
+## Satisfies Operator
+
+Validate a value matches a type without widening:
+
+```typescript
+type Color = "red" | "green" | "blue";
+type ColorMap = Record<Color, string | number[]>;
+
+const palette = {
+  red: "#ff0000",
+  green: [0, 255, 0],
+  blue: "#0000ff",
+} satisfies ColorMap;
+
+// palette.red is narrowed to string, not string | number[]
+const hex: string = palette.red; // OK — no assertion needed
+```
+
+## Const Assertions
+
+```typescript
+// Without as const — type is { method: string; url: string }
+const config1 = { method: "GET", url: "/api" };
+
+// With as const — type is { readonly method: "GET"; readonly url: "/api" }
+const config2 = { method: "GET", url: "/api" } as const;
+
+// Array becomes readonly tuple
+const statuses = ["active", "inactive", "pending"] as const;
+// type: readonly ["active", "inactive", "pending"]
+
+type Status = (typeof statuses)[number];
+// "active" | "inactive" | "pending"
+```
+
+## Declaration Merging
+
+### Interface merging
+
+```typescript
+interface Config {
+  host: string;
+  port: number;
+}
+
+// Later in code or another file — merges with above
+interface Config {
+  debug: boolean;
+}
+
+// Result: Config has host, port, and debug
+```
+
+### Module augmentation
+
+```typescript
+// Extend an existing module's types
+declare module "./types" {
+  interface AppConfig {
+    newFeatureFlag: boolean;
+  }
+}
+```

--- a/.mcp.json
+++ b/.mcp.json
@@ -3,21 +3,6 @@
     "awos-recruitment": {
       "type": "http",
       "url": "https://recruitment.awos.provectus.pro/mcp"
-    },
-    "github-mcp-server": {
-      "type": "stdio",
-      "command": "docker",
-      "args": [
-        "run",
-        "-i",
-        "--rm",
-        "-e",
-        "GITHUB_PERSONAL_ACCESS_TOKEN",
-        "ghcr.io/github/github-mcp-server"
-      ],
-      "env": {
-        "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_PERSONAL_ACCESS_TOKEN}"
-      }
     }
   }
 }

--- a/.mcp.json
+++ b/.mcp.json
@@ -3,6 +3,21 @@
     "awos-recruitment": {
       "type": "http",
       "url": "https://recruitment.awos.provectus.pro/mcp"
+    },
+    "github-mcp-server": {
+      "type": "stdio",
+      "command": "docker",
+      "args": [
+        "run",
+        "-i",
+        "--rm",
+        "-e",
+        "GITHUB_PERSONAL_ACCESS_TOKEN",
+        "ghcr.io/github/github-mcp-server"
+      ],
+      "env": {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_PERSONAL_ACCESS_TOKEN}"
+      }
     }
   }
 }

--- a/context/product/architecture.md
+++ b/context/product/architecture.md
@@ -1,0 +1,50 @@
+# System Architecture Overview: My Own AngularJS
+
+---
+
+## 1. Application & Technology Stack
+
+- **Language:** TypeScript 5.x with strict mode (`strict`, `strictNullChecks`, `noImplicitAny`, `noUncheckedIndexedAccess`)
+- **Module System:** Dual ESM + CommonJS output for maximum consumer compatibility
+- **Bundler:** Rollup — mature library bundler with excellent tree-shaking and multi-format output support
+- **Runtime Target:** Modern evergreen browsers (Chrome, Firefox, Safari, Edge — latest 2 versions)
+- **Package Structure:** Single package with all modules in `src/` — one unified `my-own-angularjs` npm package
+
+---
+
+## 2. Testing & Quality Assurance
+
+- **Test Framework:** Vitest — fast, TypeScript-native, with built-in coverage reporting
+- **DOM Environment:** jsdom (via Vitest) — lightweight in-process DOM simulation for directive and compilation tests
+- **Reference Implementation:** [angular/angular.js](https://github.com/angular/angular.js/) — the original AngularJS repository serves as the reference for feature behavior and test coverage. All unit tests should validate behavior parity with the original AngularJS test suite.
+- **Linter:** ESLint with TypeScript parser and recommended rulesets
+- **Formatter:** Prettier — enforced code formatting for consistency across the codebase
+- **Coverage Target:** 90%+ on core modules (scopes, injector, compiler, parser)
+
+---
+
+## 3. Package & Distribution
+
+- **Package Manager:** pnpm — fast, disk-efficient dependency management with strict resolution
+- **Registry:** npm (public) — published as an installable npm package
+- **Type Declarations:** Bundled `.d.ts` files generated from source via TypeScript compiler
+- **Package Exports:** Dual `main` (CJS) and `module` (ESM) entry points with `exports` map in `package.json`
+- **Versioning:** Semantic Versioning (SemVer)
+
+---
+
+## 4. CI/CD & Automation
+
+- **CI Platform:** GitHub Actions — runs on every push and pull request
+- **CI Pipeline:** Lint → Type Check → Test → Build → Coverage Report
+- **Publish Workflow:** Automated npm publish on tagged releases via GitHub Actions
+- **Branch Protection:** Required passing CI checks before merge to `master`
+
+---
+
+## 5. Development Tooling & DX
+
+- **Editor Support:** Full TypeScript IntelliSense via `tsconfig.json` with strict settings
+- **Pre-commit Hooks:** Husky + lint-staged for running linter and formatter on staged files
+- **Documentation:** API docs generated from TypeScript source using TypeDoc
+- **Scripts:** Standardized `pnpm` scripts for `build`, `test`, `lint`, `format`, and `dev`

--- a/context/product/product-definition-lite.md
+++ b/context/product/product-definition-lite.md
@@ -1,0 +1,23 @@
+# My Own AngularJS — Product Summary
+
+## Vision
+
+A complete TypeScript reimplementation of AngularJS for learning, reference, and real-world use. Install it and use it as a fully typed drop-in replacement.
+
+## Target Audience
+
+- Frontend developers wanting to understand framework internals
+- TypeScript learners seeking a real-world typed codebase
+- Open-source community members looking for a modern AngularJS reference
+
+## Core Features
+
+- Scopes & Digest Cycle (dirty checking, watchers, scope events)
+- Dependency Injection (modules, providers, injector)
+- Expressions & Filters (parser, interpolation, built-in filters)
+- Directives & DOM Compilation (compile, link, transclusion, built-in directives)
+- HTTP & Networking ($http, interceptors)
+- Routing (route config, views, parameters)
+- Forms & Validation (ngModel, validators)
+- Animations (CSS and JS-based)
+- Promises & Async ($q, $timeout, $interval)

--- a/context/product/product-definition.md
+++ b/context/product/product-definition.md
@@ -1,0 +1,84 @@
+# Product Definition: My Own AngularJS
+
+- **Version:** 1.0
+- **Status:** Proposed
+
+---
+
+## 1. The Big Picture (The "Why")
+
+### 1.1. Project Vision & Purpose
+
+To create a complete, fully typed TypeScript reimplementation of AngularJS that serves as both a deep learning exercise in framework internals and a clean, well-documented reference implementation. Users should be able to install and use it as a drop-in replacement for AngularJS, benefiting from full TypeScript support and modern code quality.
+
+### 1.2. Target Audience
+
+- **The author (personal learning):** Deepening understanding of how frontend frameworks work internally by building one from scratch.
+- **Frontend developers:** Developers who want to understand how AngularJS works under the hood by reading a clean, typed codebase.
+- **TypeScript learners:** Developers learning TypeScript by seeing a real-world framework rewritten with full type safety.
+- **Open-source community:** Contributors and users looking for a modern, typed alternative/reference of AngularJS.
+
+### 1.3. User Personas
+
+- **Persona 1: "Alex the Curious Developer"**
+  - **Role:** Mid-level frontend developer working with Angular or React.
+  - **Goal:** Wants to understand how dirty checking, digest cycles, and dependency injection actually work at a low level to become a stronger engineer.
+  - **Frustration:** The original AngularJS source code is hard to read, lacks types, and has years of accumulated complexity.
+
+- **Persona 2: "Jordan the TypeScript Enthusiast"**
+  - **Role:** Developer transitioning from JavaScript to TypeScript.
+  - **Goal:** Wants to study a non-trivial TypeScript project that applies advanced typing patterns (generics, mapped types, etc.) in a real framework context.
+  - **Frustration:** Most TypeScript examples are trivial; real-world codebases are too large to learn from easily.
+
+### 1.4. Success Metrics
+
+- **Feature coverage:** Percentage of core AngularJS features successfully reimplemented in TypeScript — target: full coverage of all major AngularJS modules.
+- **Test coverage:** High test coverage ensuring correctness and serving as living documentation — target: 90%+ coverage on core modules.
+- **Code quality:** Clean, well-documented TypeScript code that serves as a clear reference — measured by consistent patterns, strong typing, and readable implementations.
+
+---
+
+## 2. The Product Experience (The "What")
+
+### 2.1. Core Features
+
+- **Scopes & Digest Cycle:** Full scope hierarchy, dirty checking, `$watch`, `$digest`, `$apply`, `$eval`, `$evalAsync`, `$applyAsync`, scope events (`$on`, `$emit`, `$broadcast`), and scope lifecycle.
+- **Dependency Injection:** Module system, providers, factories, services, constants, values, decorators, and the injector.
+- **Expressions & Filters:** Expression parser, interpolation, one-time bindings, and built-in filters.
+- **Directives & DOM Compilation:** Directive definition, compilation, linking (pre/post), transclusion, template loading, and built-in directives (`ng-if`, `ng-repeat`, `ng-class`, `ng-model`, etc.).
+- **HTTP & Networking:** `$http` service, interceptors, request/response transformations.
+- **Routing:** Route configuration, view management, route parameters, and navigation.
+- **Forms & Validation:** `ngModel`, form controllers, built-in validators, custom validation.
+- **Animations:** Animation hooks, CSS and JavaScript-based animations.
+- **Promises & Async:** `$q` promise implementation, `$timeout`, `$interval`.
+
+### 2.2. User Journey
+
+A developer discovers the project on GitHub, clones the repository, and runs `npm install`. They can either:
+
+1. **Use it as a library:** Import the package into their own project and use it like they would use AngularJS, but with full TypeScript autocompletion, type checking, and modern tooling support.
+2. **Learn from it:** Browse the well-structured source code, read the tests as living documentation, and step through the implementation to understand how each AngularJS concept is built from the ground up.
+
+---
+
+## 3. Project Boundaries
+
+### 3.1. What's In-Scope for this Version
+
+- Full reimplementation of all major AngularJS features in TypeScript.
+- Scopes, digest cycle, and dirty checking.
+- Dependency injection system (modules, providers, injector).
+- Expression parser and filters.
+- Directive compilation and linking system.
+- Built-in directives and services.
+- HTTP service and routing.
+- Forms, validation, and animations.
+- Comprehensive test suite covering all modules.
+- Usable as an installable npm package.
+
+### 3.2. What's Out-of-Scope (Non-Goals)
+
+- **Angular 2+ compatibility:** No compatibility with Angular 2+ APIs or migration path. This project reimplements AngularJS (1.x) only.
+- **Server-side rendering:** No SSR support in initial versions.
+- **IE/legacy browser support:** No support for Internet Explorer or legacy browser quirks. Targets modern browsers only.
+- **Third-party module reimplementation:** No reimplementation of community modules like ui-router, angular-material, or other ecosystem libraries.

--- a/context/product/roadmap.md
+++ b/context/product/roadmap.md
@@ -1,0 +1,101 @@
+# Product Roadmap: My Own AngularJS
+
+_This roadmap outlines our strategic direction based on the product definition. It focuses on the "what" and "why," not the technical "how."_
+
+---
+
+### Phase 0 — Legacy Migration & Fresh Start
+
+_Move existing code to a legacy folder, reimplement from scratch in clean TypeScript, validate parity, then remove legacy._
+
+- [ ] **Legacy Isolation**
+  - [ ] **Move Existing Code:** Relocate all current source files (`src/modules/Scope/`, `src/js_legacy/`, `src/util/`) into a `legacy/` folder for reference.
+  - [ ] **Move Existing Tests:** Relocate current test files (`src/__tests__/`) into `legacy/` alongside the source they test.
+  - [ ] **Set Up Fresh Project Structure:** Initialize a clean `src/` directory with the new TypeScript strict configuration, Vitest, and Rollup build pipeline.
+
+- [ ] **Reimplement Existing Features (from scratch)**
+  - [ ] **Scopes & Digest Cycle:** Rewrite the full Scope module in clean TypeScript — `$watch`, `$watchGroup`, `$watchCollection`, `$digest`, `$apply`, `$eval`, `$evalAsync`, `$applyAsync`, scope hierarchy, events (`$on`, `$emit`, `$broadcast`), and lifecycle (`$new`, `$destroy`).
+  - [ ] **Expression Parser:** Rewrite the lexer, AST builder, and expression compiler in TypeScript with full type safety.
+  - [ ] **Utility Functions:** Rewrite helper/utility functions in TypeScript.
+
+- [ ] **Validate & Remove Legacy**
+  - [ ] **Test Parity:** Ensure all new implementations pass equivalent tests to the legacy code, using the original AngularJS test suite as reference.
+  - [ ] **Remove Legacy Folder:** Once parity is confirmed, delete the `legacy/` folder entirely.
+
+---
+
+### Phase 1 — Core Runtime Foundation
+
+_Complete the essential building blocks that everything else depends on._
+
+- [ ] **Scopes & Digest Cycle (remaining)**
+  - [ ] **Phase tracking:** Implement `$beginPhase`, `$clearPhase`, and `$$postDigest` hooks.
+  - [ ] **TTL configuration:** Support configurable digest TTL and cycle detection.
+
+- [ ] **Dependency Injection**
+  - [ ] **Module System:** Implement `angular.module()` with support for dependencies between modules.
+  - [ ] **Injector:** Implement the injector with `invoke`, `get`, `has`, `annotate`, and support for `$inject` annotations and array-style DI.
+  - [ ] **Providers & Recipes:** Implement `provider`, `factory`, `service`, `value`, `constant`, and `decorator`.
+  - [ ] **Config & Run Blocks:** Support module-level `config()` and `run()` lifecycle hooks.
+
+---
+
+### Phase 2 — Expressions, Filters & DOM
+
+_The layer that connects the runtime to templates and the DOM._
+
+- [ ] **Expressions & Parser**
+  - [ ] **Expression Parser:** Implement a full expression parser supporting property access, method calls, operators, literals, and assignments.
+  - [ ] **One-Time Bindings:** Support `::` prefix for expressions that unwatch after stabilization.
+  - [ ] **Interpolation:** Implement `$interpolate` service for `{{expression}}` resolution in strings and templates.
+
+- [ ] **Filters**
+  - [ ] **Filter Registration & Pipeline:** Implement the filter system with `$filterProvider` and chained filter expressions.
+  - [ ] **Built-in Filters:** Implement core filters (`filter`, `orderBy`, `limitTo`, `currency`, `number`, `date`, `uppercase`, `lowercase`, `json`).
+
+- [ ] **Directives & DOM Compilation**
+  - [ ] **Compiler ($compile):** Implement directive collection, sorting by priority, and terminal directives.
+  - [ ] **Linking (Pre & Post):** Implement the compile-link separation with pre-link and post-link functions.
+  - [ ] **Transclusion:** Support basic and multi-slot transclusion.
+  - [ ] **Template Loading:** Support inline templates and `templateUrl` with async loading.
+  - [ ] **Built-in Directives:** Implement `ng-if`, `ng-show`, `ng-hide`, `ng-repeat`, `ng-class`, `ng-style`, `ng-click`, `ng-bind`, `ng-switch`, `ng-include`.
+
+---
+
+### Phase 3 — Services, HTTP & Forms
+
+_High-level services that enable real application development._
+
+- [ ] **Promises & Async**
+  - [ ] **$q Promise Implementation:** Implement `$q` with `defer`, `resolve`, `reject`, `all`, `race`, and `when`.
+  - [ ] **$timeout & $interval:** Implement digest-integrated timer services with cancellation support.
+
+- [ ] **HTTP & Networking**
+  - [ ] **$http Service:** Implement request methods (`GET`, `POST`, `PUT`, `DELETE`), default headers, and parameter serialization.
+  - [ ] **Interceptors:** Support request/response interceptors and transformations.
+
+- [ ] **Forms & Validation**
+  - [ ] **ngModel:** Implement two-way data binding for form elements with `$viewValue` / `$modelValue` pipeline.
+  - [ ] **Form & NgModelController:** Implement `$dirty`, `$pristine`, `$valid`, `$invalid`, `$touched`, `$untouched` state tracking.
+  - [ ] **Built-in Validators:** Implement `required`, `minlength`, `maxlength`, `pattern`, `email`, `number`, `url`.
+  - [ ] **Custom Validators:** Support `$validators` and `$asyncValidators` pipeline.
+
+---
+
+### Phase 4 — Routing, Animations & Polish
+
+_Features that complete the full framework experience._
+
+- [ ] **Routing**
+  - [ ] **$routeProvider:** Implement route configuration with `when`, `otherwise`, and parameterized URL patterns.
+  - [ ] **ng-view:** Implement the view directive that renders route templates.
+  - [ ] **Route Lifecycle:** Support `resolve`, route change events (`$routeChangeStart`, `$routeChangeSuccess`, `$routeChangeError`), and `$routeParams`.
+
+- [ ] **Animations**
+  - [ ] **$animate Service:** Implement animation hooks for `enter`, `leave`, `move`, `addClass`, `removeClass`.
+  - [ ] **CSS Animations:** Support CSS transition and keyframe-based animations triggered by directive lifecycle.
+  - [ ] **JavaScript Animations:** Support programmatic animation definitions via `.animation()`.
+
+- [ ] **Package & Distribution**
+  - [ ] **npm Package:** Bundle and publish as an installable npm package with full TypeScript type declarations.
+  - [ ] **API Documentation:** Generate API docs from the typed source code.


### PR DESCRIPTION
## Summary

- Add product definition, roadmap (with Phase 0 legacy migration), and architecture documents under `context/product/`
- Set up 5 specialist agents (`typescript-framework`, `vitest-testing`, `rollup-build`, `ci-tooling`, `typedoc-docs`) in `.claude/agents/`
- Install skills from AWOS registry: `typescript-development`, `gha-diagnosis`, `docs-that-work`
- Configure MCP servers in `.mcp.json`

## Test plan

- [ ] Verify `context/product/` files are well-formed markdown
- [ ] Verify `.claude/agents/` files have valid YAML frontmatter
- [ ] Verify `.claude/skills/` are properly structured
- [ ] Verify `.mcp.json` is valid JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)