### PR TITLE
feat: implement configurable digest TTL (spec 006)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,19 @@ This project is being fully rewritten using [Claude Code](https://claude.ai/code
 - **Expression Parser** -- Lexer, AST builder, and tree-walking interpreter supporting literals, identifiers, member access, function calls, and scope/locals resolution
 - **Utility Functions** -- Type guards (`isString`, `isNumber`, `isObject`, etc.), deep equality (`isEqual`), deep clone (`copy`), iteration (`forEach`), and helpers (`noop`, `createMap`, `range`)
 
+### Improvements Over Original AngularJS
+
+While maintaining behavioral parity, this implementation introduces several enhancements:
+
+- **Configurable digest TTL** -- Set the maximum digest iterations per scope hierarchy via `Scope.create({ ttl: 20 })` instead of a hardcoded limit
+- **Improved error diagnostics** -- TTL breach errors include the watch function source to help identify unstable watchers
+- **Full TypeScript type guards** -- All type-checking functions (`isString`, `isObject`, etc.) are proper type guards that narrow types in conditionals
+- **Generic type safety** -- `Scope.create<T>()` provides typed scope properties, `isArray<T>()` preserves element types from union inputs
+- **Tree-walking interpreter** -- Expression parser uses a safe AST interpreter instead of `new Function()` code generation, eliminating CSP violations
+
 ### Upcoming
 
-- **Phase 1** -- Dependency Injection (modules, injector, providers)
+- **Phase 1** -- Configurable digest TTL, Dependency Injection (modules, injector, providers)
 - **Phase 2** -- Expressions & Filters, Directives & DOM Compilation
 - **Phase 3** -- HTTP, Forms & Validation, Promises
 - **Phase 4** -- Routing, Animations, npm Package

--- a/context/product/roadmap.md
+++ b/context/product/roadmap.md
@@ -32,9 +32,9 @@ _Move existing code to a legacy folder, reimplement from scratch in clean TypeSc
 
 _Complete the essential building blocks that everything else depends on._
 
-- [ ] **Scopes & Digest Cycle (remaining)**
-  - [ ] **Phase tracking:** Implement `$beginPhase`, `$clearPhase`, and `$$postDigest` hooks.
-  - [ ] **TTL configuration:** Support configurable digest TTL and cycle detection.
+- [x] **Scopes & Digest Cycle (remaining)**
+  - [x] **Phase tracking:** Implement `$beginPhase`, `$clearPhase`, and `$$postDigest` hooks.
+  - [x] **TTL configuration:** Support configurable digest TTL and cycle detection.
 
 - [ ] **Dependency Injection**
   - [ ] **Module System:** Implement `angular.module()` with support for dependencies between modules.

--- a/context/spec/006-configurable-digest-ttl/functional-spec.md
+++ b/context/spec/006-configurable-digest-ttl/functional-spec.md
@@ -1,7 +1,7 @@
 # Functional Specification: Scopes — Configurable Digest TTL
 
 - **Roadmap Item:** Phase 1 — Core Runtime Foundation > Scopes & Digest Cycle (remaining)
-- **Status:** Draft
+- **Status:** Completed
 - **Author:** Mgrdich
 
 ---
@@ -28,10 +28,10 @@ The `Scope.create()` factory method must accept an optional configuration object
 
 **Acceptance Criteria:**
 
-- [ ] `Scope.create()` with no arguments uses a default TTL of 10
-- [ ] `Scope.create({ ttl: 20 })` sets the digest TTL to 20 for that root scope
-- [ ] Child scopes (via `$new()`) inherit the root scope's TTL
-- [ ] TTL must be >= 2; values below 2 throw an error at creation time
+- [x] `Scope.create()` with no arguments uses a default TTL of 10
+- [x] `Scope.create({ ttl: 20 })` sets the digest TTL to 20 for that root scope
+- [x] Child scopes (via `$new()`) inherit the root scope's TTL
+- [x] TTL must be >= 2; values below 2 throw an error at creation time
 
 ### 2.2 Improved TTL Exceeded Error Message
 
@@ -39,8 +39,8 @@ When the digest does not stabilize within the configured TTL, the error message 
 
 **Acceptance Criteria:**
 
-- [ ] When TTL is exceeded, the error includes the last watch expression or function that was still dirty
-- [ ] The error message is actionable — a developer can use it to identify the problematic watcher
+- [x] When TTL is exceeded, the error includes the last watch expression or function that was still dirty
+- [x] The error message is actionable — a developer can use it to identify the problematic watcher
 
 ### 2.3 Phase Tracking (Already Implemented)
 
@@ -48,8 +48,8 @@ Phase tracking (`$beginPhase`, `$clearPhase`, `$$postDigest`, `$$phase`) is alre
 
 **Acceptance Criteria:**
 
-- [ ] `$$phase` is `'$digest'` during digest, `'$apply'` during apply, `null` otherwise (already passing)
-- [ ] `$$postDigest` callbacks run after the digest completes (already passing)
+- [x] `$$phase` is `'$digest'` during digest, `'$apply'` during apply, `null` otherwise (already passing)
+- [x] `$$postDigest` callbacks run after the digest completes (already passing)
 
 ---
 

--- a/context/spec/006-configurable-digest-ttl/functional-spec.md
+++ b/context/spec/006-configurable-digest-ttl/functional-spec.md
@@ -1,0 +1,70 @@
+# Functional Specification: Scopes — Configurable Digest TTL
+
+- **Roadmap Item:** Phase 1 — Core Runtime Foundation > Scopes & Digest Cycle (remaining)
+- **Status:** Draft
+- **Author:** Mgrdich
+
+---
+
+## 1. Overview and Rationale (The "Why")
+
+The Scope module was reimplemented in Phase 0 with a hardcoded digest TTL of 10 iterations. Phase tracking (`$beginPhase`, `$clearPhase`, `$$postDigest`, `$$phase`) is already fully implemented and tested.
+
+**Problem:** The fixed TTL of 10 is not always appropriate. In complex applications with many interdependent watchers, 10 iterations may not be enough to reach stability. Conversely, in simpler apps, a lower TTL could catch infinite loops faster. Additionally, when the digest does exceed the TTL, the current error message is generic and does not help developers identify which watcher is causing the instability.
+
+**Desired outcome:** Developers can configure the digest TTL when creating the root scope. When the TTL is exceeded, the error message includes information about which watcher(s) failed to stabilize, making debugging significantly easier.
+
+---
+
+## 2. Functional Requirements (The "What")
+
+### 2.1 Configurable TTL via Scope.create()
+
+The `Scope.create()` factory method must accept an optional configuration object that includes a `ttl` property to set the maximum number of digest iterations before throwing.
+
+- Default TTL remains 10 (backward compatible)
+- `Scope.create({ ttl: 15 })` sets the TTL to 15 for that scope hierarchy
+- The TTL is shared across the entire scope hierarchy (child scopes inherit the root's TTL)
+
+**Acceptance Criteria:**
+
+- [ ] `Scope.create()` with no arguments uses a default TTL of 10
+- [ ] `Scope.create({ ttl: 20 })` sets the digest TTL to 20 for that root scope
+- [ ] Child scopes (via `$new()`) inherit the root scope's TTL
+- [ ] TTL must be >= 2; values below 2 throw an error at creation time
+
+### 2.2 Improved TTL Exceeded Error Message
+
+When the digest does not stabilize within the configured TTL, the error message must include information about the last watcher(s) that were still dirty, helping developers identify the source of the instability.
+
+**Acceptance Criteria:**
+
+- [ ] When TTL is exceeded, the error includes the last watch expression or function that was still dirty
+- [ ] The error message is actionable — a developer can use it to identify the problematic watcher
+
+### 2.3 Phase Tracking (Already Implemented)
+
+Phase tracking (`$beginPhase`, `$clearPhase`, `$$postDigest`, `$$phase`) is already fully implemented and tested in Phase 0. No changes needed.
+
+**Acceptance Criteria:**
+
+- [ ] `$$phase` is `'$digest'` during digest, `'$apply'` during apply, `null` otherwise (already passing)
+- [ ] `$$postDigest` callbacks run after the digest completes (already passing)
+
+---
+
+## 3. Scope and Boundaries
+
+### In-Scope
+
+- Adding an optional `ttl` configuration to `Scope.create()`
+- Enforcing a minimum TTL of 2
+- Improving the TTL-exceeded error message to include unstable watcher info
+- Tests for all new behavior
+
+### Out-of-Scope
+
+- **$rootScopeProvider.digestTtl()** — Provider-based TTL configuration will be added when the Dependency Injection module is implemented (Phase 1)
+- **Dependency Injection** — Module system, injector, providers are a separate roadmap item
+- **Expressions & Parser enhancements** — One-time bindings, interpolation are Phase 2 items
+- **Filters, Directives, HTTP, Forms, Routing, Animations** — Later phases

--- a/context/spec/006-configurable-digest-ttl/tasks.md
+++ b/context/spec/006-configurable-digest-ttl/tasks.md
@@ -1,0 +1,16 @@
+# Tasks: Scopes — Configurable Digest TTL
+
+- **Specification:** `context/spec/006-configurable-digest-ttl/`
+- **Status:** Not Started
+
+---
+
+- [ ] **Slice 1: Configurable TTL via Scope.create()**
+  - [ ] Add `ScopeOptions` interface (`{ ttl?: number }`) and `$$ttl` property to the Scope class. Update `Scope.create()` to accept optional `ScopeOptions`. Validate `ttl >= 2` at creation time. Update `$digest()` to use `this.$root.$$ttl` instead of the hardcoded constant. Ensure child and isolated scopes inherit root's TTL. **[Agent: typescript-framework]**
+  - [ ] Add tests: default TTL of 10, custom TTL (`{ ttl: 20 }`, `{ ttl: 5 }`), validation rejects `ttl < 2`, child scopes inherit TTL, isolated scopes inherit TTL. Update existing tests that assert on the hardcoded error message. **[Agent: vitest-testing]**
+  - [ ] Verify: `pnpm test` passes, `pnpm typecheck` passes, `pnpm lint` passes. **[Agent: typescript-framework]**
+
+- [ ] **Slice 2: Improved TTL Error Message**
+  - [ ] Update the TTL breach error in `$digest()` to include the configured TTL value and `watchFn.toString()` of the last dirty watcher (`$$lastDirtyWatch`). **[Agent: typescript-framework]**
+  - [ ] Add tests: error message includes the TTL value, error message includes the watch function source string. **[Agent: vitest-testing]**
+  - [ ] Verify: `pnpm test` passes, `pnpm typecheck` passes, `pnpm lint` passes. **[Agent: typescript-framework]**

--- a/context/spec/006-configurable-digest-ttl/tasks.md
+++ b/context/spec/006-configurable-digest-ttl/tasks.md
@@ -1,16 +1,16 @@
 # Tasks: Scopes — Configurable Digest TTL
 
 - **Specification:** `context/spec/006-configurable-digest-ttl/`
-- **Status:** Not Started
+- **Status:** Complete
 
 ---
 
-- [ ] **Slice 1: Configurable TTL via Scope.create()**
-  - [ ] Add `ScopeOptions` interface (`{ ttl?: number }`) and `$$ttl` property to the Scope class. Update `Scope.create()` to accept optional `ScopeOptions`. Validate `ttl >= 2` at creation time. Update `$digest()` to use `this.$root.$$ttl` instead of the hardcoded constant. Ensure child and isolated scopes inherit root's TTL. **[Agent: typescript-framework]**
-  - [ ] Add tests: default TTL of 10, custom TTL (`{ ttl: 20 }`, `{ ttl: 5 }`), validation rejects `ttl < 2`, child scopes inherit TTL, isolated scopes inherit TTL. Update existing tests that assert on the hardcoded error message. **[Agent: vitest-testing]**
-  - [ ] Verify: `pnpm test` passes, `pnpm typecheck` passes, `pnpm lint` passes. **[Agent: typescript-framework]**
+- [x] **Slice 1: Configurable TTL via Scope.create()**
+  - [x] Add `ScopeOptions` interface (`{ ttl?: number }`) and `$$ttl` property to the Scope class. Update `Scope.create()` to accept optional `ScopeOptions`. Validate `ttl >= 2` at creation time. Update `$digest()` to use `this.$root.$$ttl` instead of the hardcoded constant. Ensure child and isolated scopes inherit root's TTL. **[Agent: typescript-framework]**
+  - [x] Add tests: default TTL of 10, custom TTL (`{ ttl: 20 }`, `{ ttl: 5 }`), validation rejects `ttl < 2`, child scopes inherit TTL, isolated scopes inherit TTL. Update existing tests that assert on the hardcoded error message. **[Agent: vitest-testing]**
+  - [x] Verify: `pnpm test` passes, `pnpm typecheck` passes, `pnpm lint` passes. **[Agent: typescript-framework]**
 
-- [ ] **Slice 2: Improved TTL Error Message**
-  - [ ] Update the TTL breach error in `$digest()` to include the configured TTL value and `watchFn.toString()` of the last dirty watcher (`$$lastDirtyWatch`). **[Agent: typescript-framework]**
-  - [ ] Add tests: error message includes the TTL value, error message includes the watch function source string. **[Agent: vitest-testing]**
-  - [ ] Verify: `pnpm test` passes, `pnpm typecheck` passes, `pnpm lint` passes. **[Agent: typescript-framework]**
+- [x] **Slice 2: Improved TTL Error Message**
+  - [x] Update the TTL breach error in `$digest()` to include the configured TTL value and `watchFn.toString()` of the last dirty watcher (`$$lastDirtyWatch`). **[Agent: typescript-framework]**
+  - [x] Add tests: error message includes the TTL value, error message includes the watch function source string. **[Agent: vitest-testing]**
+  - [x] Verify: `pnpm test` passes, `pnpm typecheck` passes, `pnpm lint` passes. **[Agent: typescript-framework]**

--- a/context/spec/006-configurable-digest-ttl/technical-considerations.md
+++ b/context/spec/006-configurable-digest-ttl/technical-considerations.md
@@ -1,7 +1,7 @@
 # Technical Specification: Scopes — Configurable Digest TTL
 
 - **Functional Specification:** `context/spec/006-configurable-digest-ttl/functional-spec.md`
-- **Status:** Draft
+- **Status:** Completed
 - **Author(s):** Mgrdich
 
 ---

--- a/context/spec/006-configurable-digest-ttl/technical-considerations.md
+++ b/context/spec/006-configurable-digest-ttl/technical-considerations.md
@@ -1,0 +1,90 @@
+# Technical Specification: Scopes — Configurable Digest TTL
+
+- **Functional Specification:** `context/spec/006-configurable-digest-ttl/functional-spec.md`
+- **Status:** Draft
+- **Author(s):** Mgrdich
+
+---
+
+## 1. High-Level Technical Approach
+
+Modify the existing Scope module to support a configurable digest TTL. The TTL is stored on the root scope instance and shared across the hierarchy. The `Scope.create()` factory gains an optional options parameter. The `$digest()` method reads the TTL from the root scope instead of a module-level constant. The error message on TTL breach includes `watchFn.toString()` of the last dirty watcher.
+
+No new files. No architectural changes. Changes are confined to `src/core/scope.ts` and its test file.
+
+---
+
+## 2. Proposed Solution & Implementation Plan
+
+### Component Breakdown
+
+**File: `src/core/scope.ts`**
+
+1. **Add `ScopeOptions` interface:**
+   - `{ ttl?: number }` — optional, defaults to 10
+   - Validate `ttl >= 2` at creation time, throw if invalid
+
+2. **Add `$$ttl` property to Scope class:**
+   - Stored on every scope instance, set from root during `$new()`
+   - Root scope sets it from `ScopeOptions.ttl ?? 10`
+
+3. **Update `Scope.create()`:**
+   - Accept optional `ScopeOptions` parameter: `Scope.create<T>(options?: ScopeOptions)`
+   - Pass `ttl` to the constructor or set after creation
+
+4. **Update `$digest()`:**
+   - Replace `let ttl = TTL` with `let ttl = this.$root.$$ttl`
+   - On TTL breach, build error message including:
+     - The configured TTL value (interpolated, not hardcoded `'10'`)
+     - `this.$root.$$lastDirtyWatch.watchFn.toString()` to identify the unstable watcher
+   - Remove or keep the module-level `const TTL = 10` as a default constant
+
+5. **Update `$new()`:**
+   - Child scopes (both prototypal and isolated) inherit `$$ttl` from `this.$root.$$ttl`
+
+### Key Implementation Details
+
+| Change | Location | Detail |
+|---|---|---|
+| `ScopeOptions` type | `src/core/scope-types.ts` or inline in `scope.ts` | `{ ttl?: number }` |
+| `$$ttl` property | Scope class | `number`, default `10`, set in constructor |
+| `Scope.create()` | Factory method | Add optional `options?: ScopeOptions` param |
+| `$digest()` TTL usage | Line ~219, ~241-242 | Use `this.$root.$$ttl`, interpolate in error |
+| Error message | Line ~241-242 | Include TTL value and `watchFn.toString()` |
+| TTL validation | `Scope.create()` | Throw if `ttl < 2` |
+
+---
+
+## 3. Impact and Risk Analysis
+
+### System Dependencies
+
+- **No external dependencies.** Changes are internal to the Scope module.
+- **Backward compatible.** `Scope.create()` with no arguments behaves identically to before (TTL defaults to 10).
+- **Test file:** Existing TTL tests may need adjustment since the error message format changes.
+
+### Potential Risks & Mitigations
+
+| Risk | Impact | Mitigation |
+|---|---|---|
+| Changing the error message breaks existing test assertions | Low | Update test assertions to match new message format |
+| `watchFn.toString()` output varies across environments | Low | Used only in error messages, not for logic. Acceptable variance. |
+| `$$ttl` property name conflicts | Very low | `$$` prefix follows AngularJS convention for internal properties |
+
+---
+
+## 4. Testing Strategy
+
+- **Location:** `src/core/__tests__/scope.test.ts`
+- **Framework:** Vitest
+- **New tests:**
+  - `Scope.create()` with no args uses default TTL of 10
+  - `Scope.create({ ttl: 20 })` allows 20 iterations before throwing
+  - `Scope.create({ ttl: 5 })` throws after 5 iterations
+  - `Scope.create({ ttl: 1 })` throws at creation time (minimum 2)
+  - `Scope.create({ ttl: 0 })` throws at creation time
+  - Child scopes inherit root's TTL
+  - Isolated scopes inherit root's TTL
+  - Error message includes the TTL value
+  - Error message includes the watch function string
+- **Existing tests:** Update any tests that assert on the exact error message `'10 digest iterations reached'`

--- a/src/core/__tests__/scope.test.ts
+++ b/src/core/__tests__/scope.test.ts
@@ -103,7 +103,7 @@ describe('Scope', () => {
 
       expect(() => {
         scope.$digest();
-      }).toThrow('10 digest iterations reached');
+      }).toThrow(/digest/);
     });
 
     it('handles NaN correctly (NaN === NaN for dirty checking)', () => {
@@ -178,6 +178,193 @@ describe('Scope', () => {
 
       scope.$digest();
       expect(counter).toBe(1);
+    });
+  });
+
+  describe('$digest TTL', () => {
+    /**
+     * Build a watcher whose watch function changes value on each pass
+     * until it has been observed `dirtyPasses` times, then stabilizes.
+     *
+     * With $digest semantics, `dirtyPasses` dirty passes followed by one
+     * clean pass means the digest performs `dirtyPasses + 1` total iterations
+     * before exiting the do/while loop.
+     */
+    const attachConvergingWatcher = (scope: Scope, dirtyPasses: number): void => {
+      let counter = 0;
+      scope.$watch(() => {
+        if (counter < dirtyPasses) {
+          counter++;
+        }
+        return counter;
+      });
+    };
+
+    /** Build a watcher whose watch function never stabilizes. */
+    const attachInfiniteWatcher = (scope: Scope): void => {
+      let counter = 0;
+      scope.$watch(() => {
+        counter++;
+        return counter;
+      });
+    };
+
+    describe('default TTL', () => {
+      it('defaults to 10 when no options are provided', () => {
+        const scope = Scope.create();
+        expect(scope.$$ttl).toBe(10);
+      });
+
+      it('allows a digest that requires up to 10 iterations to stabilize', () => {
+        const scope = Scope.create();
+        // 9 dirty passes + 1 clean pass = 10 total iterations -- must succeed
+        attachConvergingWatcher(scope, 9);
+
+        expect(() => {
+          scope.$digest();
+        }).not.toThrow();
+      });
+
+      it('throws when a digest cannot stabilize within 10 iterations', () => {
+        const scope = Scope.create();
+        attachInfiniteWatcher(scope);
+
+        expect(() => {
+          scope.$digest();
+        }).toThrow(/digest/);
+      });
+    });
+
+    describe('custom TTL via options', () => {
+      it('honours an increased ttl of 20', () => {
+        const scope = Scope.create({ ttl: 20 });
+        expect(scope.$$ttl).toBe(20);
+      });
+
+      it('allows a digest that requires 15 iterations on a scope with ttl 20', () => {
+        const scope = Scope.create({ ttl: 20 });
+        // 14 dirty passes + 1 clean pass = 15 total iterations
+        attachConvergingWatcher(scope, 14);
+
+        expect(() => {
+          scope.$digest();
+        }).not.toThrow();
+      });
+
+      it('throws when a digest cannot stabilize within the custom ttl of 20', () => {
+        const scope = Scope.create({ ttl: 20 });
+        attachInfiniteWatcher(scope);
+
+        expect(() => {
+          scope.$digest();
+        }).toThrow(/digest/);
+      });
+    });
+
+    describe('lower TTL via options', () => {
+      it('catches infinite loops faster with ttl 5', () => {
+        const scope = Scope.create({ ttl: 5 });
+        // 6 dirty passes would stabilize on iteration 7 with the default ttl=10,
+        // but with ttl=5 the digest must throw before it can converge.
+        attachConvergingWatcher(scope, 6);
+
+        expect(() => {
+          scope.$digest();
+        }).toThrow(/digest/);
+      });
+    });
+
+    describe('TTL validation at creation', () => {
+      it('throws when ttl is 1', () => {
+        expect(() => Scope.create({ ttl: 1 })).toThrow('TTL must be at least 2');
+      });
+
+      it('throws when ttl is 0', () => {
+        expect(() => Scope.create({ ttl: 0 })).toThrow('TTL must be at least 2');
+      });
+
+      it('throws when ttl is negative', () => {
+        expect(() => Scope.create({ ttl: -5 })).toThrow('TTL must be at least 2');
+      });
+
+      it('does not throw when ttl is exactly 2', () => {
+        expect(() => Scope.create({ ttl: 2 })).not.toThrow();
+      });
+    });
+
+    describe('child scopes inherit root TTL', () => {
+      it('child scopes copy the root TTL', () => {
+        const root = Scope.create({ ttl: 15 });
+        const child = root.$new();
+
+        expect(child.$$ttl).toBe(15);
+      });
+
+      it('a child scope can run a digest needing 12 iterations when root ttl is 15', () => {
+        const root = Scope.create({ ttl: 15 });
+        const child = root.$new();
+        // 11 dirty passes + 1 clean pass = 12 total iterations
+        // This would exceed the default ttl of 10 but fits within 15.
+        attachConvergingWatcher(child, 11);
+
+        expect(() => {
+          root.$digest();
+        }).not.toThrow();
+      });
+    });
+
+    describe('isolated scopes inherit root TTL', () => {
+      it('isolated scopes copy the root TTL', () => {
+        const root = Scope.create({ ttl: 15 });
+        const isolated = root.$new(true);
+
+        expect(isolated.$$ttl).toBe(15);
+      });
+    });
+
+    describe('error message', () => {
+      it('includes the default TTL value (10) in the error message', () => {
+        const scope = Scope.create();
+        attachInfiniteWatcher(scope);
+
+        expect(() => {
+          scope.$digest();
+        }).toThrow(/10 digest/);
+      });
+
+      it('includes the custom TTL value in the error message', () => {
+        const scope = Scope.create({ ttl: 15 });
+        attachInfiniteWatcher(scope);
+
+        expect(() => {
+          scope.$digest();
+        }).toThrow(/15 digest/);
+      });
+
+      it('includes the watch function source in the error message', () => {
+        const scope = Scope.create<{ uniqueMarkerName: number }>();
+        scope.uniqueMarkerName = 0;
+        scope.$watch(() => scope.uniqueMarkerName++);
+
+        try {
+          scope.$digest();
+          throw new Error('expected $digest to throw');
+        } catch (error: unknown) {
+          expect(error).toBeInstanceOf(Error);
+          const message = (error as Error).message;
+          expect(message).toContain('Last dirty watcher:');
+          expect(message).toContain('uniqueMarkerName');
+        }
+      });
+
+      it('still contains the "digest" substring for backward compatibility', () => {
+        const scope = Scope.create();
+        attachInfiniteWatcher(scope);
+
+        expect(() => {
+          scope.$digest();
+        }).toThrow(/digest/);
+      });
     });
   });
 

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -6,6 +6,7 @@ export type {
   InitWatchVal,
   ListenerFn,
   ScopeEvent,
+  ScopeOptions,
   ScopePhase,
   TypedScope,
   Watcher,

--- a/src/core/scope-types.ts
+++ b/src/core/scope-types.ts
@@ -51,3 +51,9 @@ export interface AsyncTask {
 
 /** Phase tracking literal union for the digest cycle. */
 export type ScopePhase = '$digest' | '$apply' | null;
+
+/** Options for configuring a Scope created via `Scope.create()`. */
+export interface ScopeOptions {
+  /** Maximum number of digest iterations before throwing. Must be >= 2. Defaults to 10. */
+  ttl?: number;
+}

--- a/src/core/scope.ts
+++ b/src/core/scope.ts
@@ -5,6 +5,7 @@ import {
   type EventListener,
   type ListenerFn,
   type ScopeEvent,
+  type ScopeOptions,
   type ScopePhase,
   type TypedScope,
   type Watcher,
@@ -48,6 +49,7 @@ export class Scope {
   $$lastDirtyWatch: Watcher<unknown> | null;
   $$applyAsyncId: ReturnType<typeof setTimeout> | null;
   $$phase: ScopePhase;
+  $$ttl: number;
 
   constructor() {
     this.$id = nextId++;
@@ -62,11 +64,17 @@ export class Scope {
     this.$$lastDirtyWatch = null;
     this.$$applyAsyncId = null;
     this.$$phase = null;
+    this.$$ttl = TTL;
   }
 
   /** Create a typed Scope instance with compile-time property access. */
-  static create<T extends Record<string, unknown> = Record<string, unknown>>(): TypedScope<T> {
-    return new Scope() as TypedScope<T>;
+  static create<T extends Record<string, unknown> = Record<string, unknown>>(options?: ScopeOptions): TypedScope<T> {
+    if (options?.ttl !== undefined && options.ttl < 2) {
+      throw new Error('TTL must be at least 2');
+    }
+    const scope = new Scope();
+    scope.$$ttl = options?.ttl ?? TTL;
+    return scope as TypedScope<T>;
   }
 
   /**
@@ -120,6 +128,7 @@ export class Scope {
     if (isolated) {
       child = new Scope();
       child.$root = this.$root;
+      child.$$ttl = this.$root.$$ttl;
       child.$$asyncQueue = this.$$asyncQueue;
       child.$$applyAsyncQueue = this.$$applyAsyncQueue;
       child.$$postDigestQueue = this.$$postDigestQueue;
@@ -216,7 +225,7 @@ export class Scope {
    * @throws When the digest does not stabilize within TTL iterations
    */
   $digest(): void {
-    let ttl = TTL;
+    let ttl = this.$root.$$ttl;
     let dirty: boolean;
 
     this.$root.$$lastDirtyWatch = null;
@@ -240,7 +249,11 @@ export class Scope {
 
         if ((dirty || this.$$asyncQueue.length > 0) && --ttl <= 0) {
           this.$clearPhase();
-          throw new Error('10 digest iterations reached');
+          const lastDirtyWatch = this.$root.$$lastDirtyWatch as Watcher<unknown> | null;
+          const lastDirtyInfo =
+            lastDirtyWatch !== null ? `\nLast dirty watcher: ${lastDirtyWatch.watchFn.toString()}` : '';
+          const ttlValue = String(this.$root.$$ttl);
+          throw new Error(`${ttlValue} digest iterations reached. Aborting!${lastDirtyInfo}`);
         }
       } while (dirty || this.$$asyncQueue.length > 0);
       // Flush any pending $applyAsync during the active digest


### PR DESCRIPTION
## Summary

- **Spec 006 — Configurable Digest TTL**: First feature of Phase 1 (Core Runtime Foundation)
- Adds `ScopeOptions` interface and `$$ttl` property to the Scope class
- `Scope.create({ ttl: N })` configures the maximum digest iterations per scope hierarchy
- Child and isolated scopes inherit the root's TTL
- TTL validation enforces minimum of 2 at creation time
- Improved TTL breach error message now includes the configured TTL value and the source of the last dirty watcher (via `watchFn.toString()`)
- Backward compatible: `Scope.create()` with no arguments still uses the default TTL of 10
- 18 new tests added (380 → 398 total)

## Test plan

- [x] `pnpm lint` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (398 tests)
- [x] `pnpm build` succeeds
- [x] All 8 acceptance criteria in functional-spec.md verified and marked \`[x]\`
- [x] Spec 006 status set to Completed
- [x] Roadmap updated — Scopes & Digest Cycle (remaining) fully complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)