### PR TITLE
feat: implement DI foundation with typed builder pattern (spec 007)

### DIFF
--- a/context/product/architecture.md
+++ b/context/product/architecture.md
@@ -10,6 +10,25 @@
 - **Runtime Target:** Modern evergreen browsers (Chrome, Firefox, Safari, Edge — latest 2 versions)
 - **Package Structure:** Single package with all modules in `src/` — one unified `my-own-angularjs` npm package
 
+### Public API Convention: ES Module Named Exports
+
+All public APIs are exposed exclusively as ES module named exports. The framework does **not** ship a global `angular` namespace constant as its primary interface — consumers import the functions and classes they need directly:
+
+```typescript
+import { Scope } from 'my-own-angularjs';
+import { parse } from 'my-own-angularjs';
+import { createModule, getModule, createInjector } from 'my-own-angularjs/di';
+```
+
+**Rationale:**
+
+- Consistent with modern TypeScript library conventions
+- Better tree-shaking — consumers only pay for what they import
+- Clearer dependency graphs and IDE auto-imports
+- No hidden global state
+
+**AngularJS compatibility layer (future milestone):** A dedicated roadmap item will add an `angular` constant that wraps all the ES module APIs (`angular.module()`, `angular.injector()`, etc.) for users migrating from classic AngularJS. This compatibility layer will be a thin wrapper — it will not duplicate any logic or maintain a separate registry. See the final phase of the roadmap for details.
+
 ---
 
 ## 2. Testing & Quality Assurance

--- a/context/product/roadmap.md
+++ b/context/product/roadmap.md
@@ -108,3 +108,26 @@ _Features that complete the full framework experience._
     - [ ] **TodoMVC:** A full TodoMVC implementation — the standard framework showcase app — demonstrating directives, two-way binding, and filtering.
     - [ ] **Form Validation Demo:** A form with validation rules demonstrating `ngModel`, built-in and custom validators, and form state tracking (`$dirty`, `$valid`, etc.).
     - [ ] **SPA with Routing:** A multi-page single-page application using `$routeProvider`, `ng-view`, route parameters, and navigation.
+
+---
+
+### Phase 5 — AngularJS Compatibility Layer
+
+_A final milestone that wraps the entire ES-module-first framework under a classic `angular` namespace, providing a familiar surface for developers migrating from original AngularJS 1.x._
+
+Throughout Phases 0–4, every feature is built and exposed as ES module named exports (`Scope`, `parse`, `createModule`, `createInjector`, `$http`, etc.) — there is no global `angular` object during development. This final phase adds a compatibility layer that wraps all of those APIs under a single `angular` constant so that code written against the classic AngularJS 1.x API can run with minimal changes._
+
+- [ ] **`angular` Namespace Constant**
+  - [ ] **Core helpers:** Expose `angular.isString`, `angular.isNumber`, `angular.isArray`, `angular.isObject`, `angular.isFunction`, `angular.isDefined`, `angular.equals`, `angular.copy`, `angular.forEach`, `angular.extend`, `angular.noop` — all delegating to the existing typed utility functions.
+  - [ ] **Module system:** `angular.module(name, requires?)` — thin wrapper over `createModule` / `getModule`.
+  - [ ] **Injector:** `angular.injector(modules)` — thin wrapper over `createInjector`.
+  - [ ] **Bootstrap:** `angular.bootstrap(element, modules, config?)` — DOM-based application startup using the existing injector and compiler.
+  - [ ] **Element wrapper:** `angular.element` — a lightweight jqLite-style wrapper (or re-export jQuery if present).
+  - [ ] **Version:** `angular.version` — compatibility version string.
+
+- [ ] **Classic API Compatibility Tests**
+  - [ ] **Snippet parity:** Run small classic AngularJS code snippets (from the official AngularJS docs) against the compatibility layer and verify they produce identical results.
+  - [ ] **Migration guide:** Document which classic AngularJS APIs are supported, which are deferred, and any behavioral differences.
+
+- [ ] **No Duplication**
+  - [ ] **Thin wrapper only:** Every entry on the `angular` namespace must delegate to an existing ES module export. No duplicated implementation, no parallel registries, no additional state.

--- a/context/product/roadmap.md
+++ b/context/product/roadmap.md
@@ -37,10 +37,10 @@ _Complete the essential building blocks that everything else depends on._
   - [x] **TTL configuration:** Support configurable digest TTL and cycle detection.
 
 - [ ] **Dependency Injection**
-  - [ ] **Module System:** Implement `angular.module()` with support for dependencies between modules.
-  - [ ] **Injector:** Implement the injector with `invoke`, `get`, `has`, `annotate`, and support for `$inject` annotations and array-style DI.
-  - [ ] **Providers & Recipes:** Implement `provider`, `factory`, `service`, `value`, `constant`, and `decorator`.
-  - [ ] **Config & Run Blocks:** Support module-level `config()` and `run()` lifecycle hooks.
+  - [x] **Module System:** Implement `createModule()` / `getModule()` (ES module style) with support for dependencies between modules. (spec 007)
+  - [x] **Injector:** Implement the injector with `invoke`, `get`, `has`, `annotate`, and support for `$inject` annotations and array-style DI. (spec 007)
+  - [ ] **Providers & Recipes:** Implement `provider`, `factory`, `service`, `value`, `constant`, and `decorator`. _(spec 007 covers `value`, `constant`, `factory`; `service`/`provider`/`decorator` deferred to spec 008)_
+  - [ ] **Config & Run Blocks:** Support module-level `config()` and `run()` lifecycle hooks. _(spec 008)_
 
 ---
 

--- a/context/spec/007-dependency-injection-foundation/functional-spec.md
+++ b/context/spec/007-dependency-injection-foundation/functional-spec.md
@@ -1,7 +1,7 @@
 # Functional Specification: Dependency Injection — Foundation
 
 - **Roadmap Item:** Phase 1 — Core Runtime Foundation > Dependency Injection
-- **Status:** Draft
+- **Status:** Completed
 - **Author:** Mgrdich
 
 ---
@@ -31,11 +31,11 @@ A classic `angular.module()` global namespace is explicitly **out of scope for t
 
 **Acceptance Criteria:**
 
-- [ ] `createModule('app', [])` creates a new module named `app` with no dependencies
-- [ ] `createModule('app', ['common'])` creates a module that depends on `common`
-- [ ] `getModule('app')` returns the previously created module
-- [ ] `getModule('app')` throws `Error('Module not found: app')` if `app` was never created
-- [ ] Creating a module with the same name twice replaces the previous registration
+- [x] `createModule('app', [])` creates a new module named `app` with no dependencies
+- [x] `createModule('app', ['common'])` creates a module that depends on `common`
+- [x] `getModule('app')` returns the previously created module
+- [x] `getModule('app')` throws `Error('Module not found: app')` if `app` was never created
+- [x] Creating a module with the same name twice replaces the previous registration
 
 ### 2.2 Module Dependency Graph
 
@@ -43,10 +43,10 @@ Modules can depend on other modules. When a module is loaded, all its transitive
 
 **Acceptance Criteria:**
 
-- [ ] When `app` depends on `common`, services registered on `common` are available in `app`
-- [ ] Transitive dependencies work: if `app` depends on `b`, and `b` depends on `c`, services from `c` are visible in `app`
-- [ ] Each module is loaded only once, even if referenced by multiple modules in the graph
-- [ ] Missing module dependencies throw a clear error (e.g., `Module not found: 'common'`)
+- [x] When `app` depends on `common`, services registered on `common` are available in `app`
+- [x] Transitive dependencies work: if `app` depends on `b`, and `b` depends on `c`, services from `c` are visible in `app`
+- [x] Each module is loaded only once, even if referenced by multiple modules in the graph
+- [x] Missing module dependencies throw a clear error (e.g., `Module not found: 'common'`)
 
 ### 2.3 Registering Services (value, constant, factory)
 
@@ -58,12 +58,12 @@ Modules must provide methods to register services using three recipes:
 
 **Acceptance Criteria:**
 
-- [ ] `module.value('apiUrl', 'https://api.example.com')` registers a string value
-- [ ] `module.value('config', { timeout: 30 })` registers an object value
-- [ ] `module.constant('MAX_RETRIES', 3)` registers a constant
-- [ ] `module.factory('logger', () => ({ log: (msg) => console.log(msg) }))` registers a factory with no dependencies
-- [ ] `module.factory('userService', ['$http', ($http) => ({ ... })])` registers a factory with dependencies using array-style annotation
-- [ ] `module.factory('userService', userServiceFn)` with `userServiceFn.$inject = ['$http']` works using the `$inject` property
+- [x] `module.value('apiUrl', 'https://api.example.com')` registers a string value
+- [x] `module.value('config', { timeout: 30 })` registers an object value
+- [x] `module.constant('MAX_RETRIES', 3)` registers a constant
+- [x] `module.factory('logger', () => ({ log: (msg) => console.log(msg) }))` registers a factory with no dependencies
+- [x] `module.factory('userService', ['$http', ($http) => ({ ... })])` registers a factory with dependencies using array-style annotation
+- [x] `module.factory('userService', userServiceFn)` with `userServiceFn.$inject = ['$http']` works using the `$inject` property
 
 ### 2.4 Injector — get and has
 
@@ -74,12 +74,12 @@ An injector must be created from a module (and its dependency graph). The inject
 
 **Acceptance Criteria:**
 
-- [ ] `injector.get('apiUrl')` returns the registered value
-- [ ] `injector.get('logger')` calls the factory function and returns its result
-- [ ] Services are singletons — `injector.get('logger') === injector.get('logger')` (same reference on every call)
-- [ ] `injector.has('apiUrl')` returns `true` for registered services
-- [ ] `injector.has('nonexistent')` returns `false`
-- [ ] `injector.get('nonexistent')` throws `Error('Unknown provider: nonexistent')`
+- [x] `injector.get('apiUrl')` returns the registered value
+- [x] `injector.get('logger')` calls the factory function and returns its result
+- [x] Services are singletons — `injector.get('logger') === injector.get('logger')` (same reference on every call)
+- [x] `injector.has('apiUrl')` returns `true` for registered services
+- [x] `injector.has('nonexistent')` returns `false`
+- [x] `injector.get('nonexistent')` throws `Error('Unknown provider: nonexistent')`
 
 ### 2.5 Injector — invoke and annotate
 
@@ -90,12 +90,12 @@ The injector must be able to invoke arbitrary functions with their dependencies 
 
 **Acceptance Criteria:**
 
-- [ ] `injector.invoke(['$http', ($http) => ...])` calls the function with `$http` injected
-- [ ] `injector.invoke(fn)` where `fn.$inject = ['$http']` also works
-- [ ] `injector.invoke(fn, self)` sets `this` to `self` inside `fn`
-- [ ] `injector.invoke(fn, null, { $http: mockHttp })` uses the mock instead of the registered `$http`
-- [ ] `injector.annotate(fn)` returns `['$http']` for both array-style and `$inject` annotated functions
-- [ ] `injector.annotate` throws a clear error if a function has no annotations (function parameter inference is not supported)
+- [x] `injector.invoke(['$http', ($http) => ...])` calls the function with `$http` injected
+- [x] `injector.invoke(fn)` where `fn.$inject = ['$http']` also works
+- [x] `injector.invoke(fn, self)` sets `this` to `self` inside `fn`
+- [x] `injector.invoke(fn, null, { $http: mockHttp })` uses the mock instead of the registered `$http`
+- [x] `injector.annotate(fn)` returns `['$http']` for both array-style and `$inject` annotated functions
+- [x] `injector.annotate` throws a clear error if a function has no annotations (function parameter inference is not supported)
 
 ### 2.6 Circular Dependency Detection
 
@@ -103,9 +103,9 @@ If a service's factory function declares a dependency that (directly or transiti
 
 **Acceptance Criteria:**
 
-- [ ] Direct cycle (`A` depends on `A`) throws `Error('Circular dependency: A <- A')`
-- [ ] Indirect cycle (`A` depends on `B`, `B` depends on `A`) throws `Error('Circular dependency: A <- B <- A')`
-- [ ] Deeper cycles (`A → B → C → A`) throw with the full dependency chain in the message
+- [x] Direct cycle (`A` depends on `A`) throws `Error('Circular dependency: A <- A')`
+- [x] Indirect cycle (`A` depends on `B`, `B` depends on `A`) throws `Error('Circular dependency: A <- B <- A')`
+- [x] Deeper cycles (`A → B → C → A`) throw with the full dependency chain in the message
 
 ### 2.7 Type Safety and Inference
 
@@ -138,14 +138,14 @@ injector.get('unknown');  // compile error — 'unknown' is not a registered key
 
 **Acceptance Criteria:**
 
-- [ ] `module.value('apiUrl', 'https://...')` infers the value as `string`
-- [ ] Each `.value()` / `.constant()` / `.factory()` call returns a module type with the new service added to its registry (builder pattern)
-- [ ] `injector.get('apiUrl')` on a typed injector returns the correct type without an explicit generic parameter
-- [ ] `injector.get('nonexistent')` is a **compile-time** error on a typed injector (in addition to the runtime error)
-- [ ] `injector.get<HttpClient>('$http')` still works as an explicit-generic escape hatch
-- [ ] `pnpm typecheck` passes with zero errors across the DI module
-- [ ] No use of `any` in the DI source code (except deliberate, commented escape hatches)
-- [ ] All public APIs have explicit types for parameters and return values
+- [x] `module.value('apiUrl', 'https://...')` infers the value as `string`
+- [x] Each `.value()` / `.constant()` / `.factory()` call returns a module type with the new service added to its registry (builder pattern)
+- [x] `injector.get('apiUrl')` on a typed injector returns the correct type without an explicit generic parameter
+- [x] `injector.get('nonexistent')` is a **compile-time** error on a typed injector (in addition to the runtime error)
+- [x] `injector.get<HttpClient>('$http')` still works as an explicit-generic escape hatch
+- [x] `pnpm typecheck` passes with zero errors across the DI module
+- [x] No use of `any` in the DI source code (except deliberate, commented escape hatches)
+- [x] All public APIs have explicit types for parameters and return values
 
 ---
 

--- a/context/spec/007-dependency-injection-foundation/functional-spec.md
+++ b/context/spec/007-dependency-injection-foundation/functional-spec.md
@@ -32,7 +32,7 @@ Developers must be able to create and retrieve modules using **both** the classi
 - `createModule('myApp', ['dep1', 'dep2'])` — creates a module
 - `getModule('myApp')` — retrieves an existing module
 
-Both APIs operate on the same module registry — a module created via `createModule` is retrievable via `angular.module` and vice versa.
+**Both APIs must share a single underlying implementation.** `angular.module()` is a thin wrapper that delegates to the same internal module registry and the same `createModule` / `getModule` code paths. There must not be two separate implementations — a module created via `createModule` is retrievable via `angular.module` and vice versa, because they are literally the same code behind the scenes.
 
 **Acceptance Criteria:**
 
@@ -42,7 +42,8 @@ Both APIs operate on the same module registry — a module created via `createMo
 - [ ] `angular.module('app')` throws a clear error if `app` was never created
 - [ ] Creating a module with the same name twice replaces the previous registration
 - [ ] `createModule()` and `getModule()` named exports work identically to `angular.module()`
-- [ ] Modules created via one API are retrievable via the other (shared registry)
+- [ ] Modules created via one API are retrievable via the other (shared registry and shared code path)
+- [ ] `angular.module` is implemented by delegating to `createModule` / `getModule` — not a second parallel implementation
 
 ### 2.2 Module Dependency Graph
 
@@ -116,25 +117,43 @@ If a service's factory function declares a dependency that (directly or transiti
 
 ### 2.7 Type Safety and Inference
 
-Every part of the DI system must be fully type-safe with proper TypeScript inference where possible. Consumers should get autocomplete, type checking, and compile-time errors for DI mistakes.
+Every part of the DI system must be fully type-safe with proper TypeScript inference. Consumers should get autocomplete, type checking, and compile-time errors for DI mistakes without having to manually annotate anything.
 
 **Key type-safety goals:**
 
-- **Typed service registration:** `module.value<T>(name, value)` infers `T` from the value argument, or accepts an explicit type parameter. Registered services have a known type.
-- **Typed injector.get:** `injector.get<T>(name)` returns `T`. Ideally, when a module's service registry is typed, `injector.get('logger')` infers the return type from the registration.
-- **Typed factories:** Factory functions have properly typed dependency parameters — `module.factory('userService', ['$http', ($http: HttpClient) => { ... }])` should type-check the `$http` parameter.
-- **$inject annotation:** The `$inject` property is typed as `readonly string[]`, and TypeScript should enforce that the annotated function's parameter count matches the `$inject` array length.
-- **No `any` leakage:** The internal injector implementation must use `unknown` instead of `any`, narrowing with type guards where needed.
-- **Generic constraints:** Where possible, use generic constraints to enforce that dependencies resolve to the correct types at the call site.
+- **Typed service registration:** `module.value(name, value)` infers the value type from the argument.
+- **String-literal-tracked registry (builder pattern):** Each `.value()`, `.constant()`, and `.factory()` call returns a new module type with the accumulated service registry, keyed by the literal string name. This lets TypeScript remember *which* services the module has registered and *what type* each one is.
+- **Typed `injector.get`:** When the injector is built from typed modules, `injector.get('apiUrl')` infers its return type from the registration — no generic parameter needed. Passing an unregistered name is a compile-time error (`Argument of type '"xyz"' is not assignable to parameter of type '"apiUrl" | "config" | "logger"'`).
+- **Typed factories:** Factory functions can declare typed dependency parameters that match the registered services.
+- **`$inject` annotation:** The `$inject` property is typed as `readonly string[]`.
+- **No `any` leakage:** The internal implementation must use `unknown` instead of `any`, narrowing with type guards where needed. The only acceptable `any` is at the annotation-parsing boundary if unavoidable, with a comment explaining why.
+- **Ergonomic escape hatch:** For advanced cases, `injector.get<T>(name)` still accepts an explicit generic as a fallback when the registry-based inference is not usable.
+
+**Example of desired developer experience:**
+
+```typescript
+const mod = createModule('app', [])
+  .value('apiUrl', 'https://api.example.com')    // registers 'apiUrl': string
+  .value('config', { timeout: 30 })              // registers 'config': { timeout: number }
+  .factory('logger', () => ({ log: (m: string) => {} })); // registers 'logger': { log: (m: string) => void }
+
+const injector = createInjector([mod]);
+injector.get('apiUrl');   // inferred as string — no generic needed
+injector.get('config');   // inferred as { timeout: number }
+injector.get('logger');   // inferred as { log: (m: string) => void }
+injector.get('unknown');  // compile error — 'unknown' is not a registered key
+```
 
 **Acceptance Criteria:**
 
 - [ ] `module.value('apiUrl', 'https://...')` infers the value as `string`
-- [ ] `injector.get<HttpClient>('$http')` returns a typed `HttpClient`
+- [ ] Each `.value()` / `.constant()` / `.factory()` call returns a module type with the new service added to its registry (builder pattern)
+- [ ] `injector.get('apiUrl')` on a typed injector returns the correct type without an explicit generic parameter
+- [ ] `injector.get('nonexistent')` is a **compile-time** error on a typed injector (in addition to the runtime error)
+- [ ] `injector.get<HttpClient>('$http')` still works as an explicit-generic escape hatch
 - [ ] `pnpm typecheck` passes with zero errors across the DI module
-- [ ] No use of `any` in the DI source code (except in deliberate, commented escape hatches at the annotation-parsing boundary if unavoidable)
+- [ ] No use of `any` in the DI source code (except deliberate, commented escape hatches)
 - [ ] All public APIs have explicit types for parameters and return values
-- [ ] Generic type parameters are used for type inference wherever they provide value (service registration, `invoke`, `get`)
 
 ---
 

--- a/context/spec/007-dependency-injection-foundation/functional-spec.md
+++ b/context/spec/007-dependency-injection-foundation/functional-spec.md
@@ -12,38 +12,30 @@ The framework currently has a standalone Scope module and Expression Parser, but
 
 **Problem:** Without DI, there is no way for modules to declare dependencies, no way to share instances across the application, and no way to build the rest of AngularJS — the entire framework is built on top of the injector.
 
-**Desired outcome:** A working module system and injector that supports registering values, constants, and factories; resolves dependencies using `$inject` property or array-style annotations; detects missing dependencies with clear error messages; and detects circular dependencies before they cause stack overflow. Everything must be fully type-safe with TypeScript inference where possible. This spec covers the foundation; `service`, `provider`, `decorator` recipes and `config`/`run` blocks are deferred to Spec 008.
+**Desired outcome:** A working module system and injector that supports registering values, constants, and factories; resolves dependencies using `$inject` property or array-style annotations; detects missing dependencies with clear error messages; and detects circular dependencies before they cause stack overflow. Everything must be fully type-safe with TypeScript inference where possible, and exposed exclusively via modern ES module named exports (consistent with how `Scope`, `parse`, and all other public APIs already work in this codebase). This spec covers the foundation; `service`, `provider`, `decorator` recipes and `config`/`run` blocks are deferred to Spec 008. A classic `angular.module()`-style global namespace is **not** part of this spec — it will be introduced later as a dedicated AngularJS compatibility layer that wraps the ES module APIs.
 
 ---
 
 ## 2. Functional Requirements (The "What")
 
-### 2.1 Module Creation and Retrieval — Two API Styles
+### 2.1 Module Creation and Retrieval
 
-Developers must be able to create and retrieve modules using **both** the classic `angular.module()` global pattern **and** modern ES module imports. Both APIs are first-class and share the same underlying module registry.
+Developers create and retrieve modules using modern ES module named exports. This is consistent with how the rest of the framework is exposed (e.g., `Scope.create`, `parse` from the parser module) — everything is a named export, nothing lives on a global namespace.
 
-**Classic AngularJS style:**
+**API:**
 
-- `angular.module('myApp', ['dep1', 'dep2'])` — creates a new module named `myApp` that depends on `dep1` and `dep2`
-- `angular.module('myApp')` — retrieves the existing module (no dependencies argument means retrieval, not creation)
+- `createModule('myApp', ['dep1', 'dep2'])` — creates a new module named `myApp` that depends on `dep1` and `dep2`
+- `getModule('myApp')` — retrieves an existing module (throws if not found)
 
-**Modern ES module style (named exports):**
-
-- `createModule('myApp', ['dep1', 'dep2'])` — creates a module
-- `getModule('myApp')` — retrieves an existing module
-
-**Both APIs must share a single underlying implementation.** `angular.module()` is a thin wrapper that delegates to the same internal module registry and the same `createModule` / `getModule` code paths. There must not be two separate implementations — a module created via `createModule` is retrievable via `angular.module` and vice versa, because they are literally the same code behind the scenes.
+A classic `angular.module()` global namespace is explicitly **out of scope for this spec**. A future "AngularJS Compatibility Layer" phase will wrap these ES module APIs under an `angular` namespace constant so users migrating from classic AngularJS have the familiar entry points. Until then, there is one API surface.
 
 **Acceptance Criteria:**
 
-- [ ] `angular.module('app', [])` creates a new module named `app` with no dependencies
-- [ ] `angular.module('app', ['common'])` creates a module that depends on `common`
-- [ ] `angular.module('app')` (no dependencies arg) returns the previously created module
-- [ ] `angular.module('app')` throws a clear error if `app` was never created
+- [ ] `createModule('app', [])` creates a new module named `app` with no dependencies
+- [ ] `createModule('app', ['common'])` creates a module that depends on `common`
+- [ ] `getModule('app')` returns the previously created module
+- [ ] `getModule('app')` throws `Error('Module not found: app')` if `app` was never created
 - [ ] Creating a module with the same name twice replaces the previous registration
-- [ ] `createModule()` and `getModule()` named exports work identically to `angular.module()`
-- [ ] Modules created via one API are retrievable via the other (shared registry and shared code path)
-- [ ] `angular.module` is implemented by delegating to `createModule` / `getModule` — not a second parallel implementation
 
 ### 2.2 Module Dependency Graph
 
@@ -161,8 +153,8 @@ injector.get('unknown');  // compile error — 'unknown' is not a registered key
 
 ### In-Scope
 
-- Module system with **both** `angular.module()` (classic global) **and** `createModule()` / `getModule()` (modern ES imports) APIs
-- Shared module registry so both APIs are interchangeable
+- Module system with ES module named exports: `createModule()` / `getModule()`
+- Single module registry shared across all DI APIs
 - Module dependency graph (including transitive dependencies)
 - Three recipes: `value`, `constant`, `factory`
 - Injector with `get`, `has`, `invoke`, `annotate`
@@ -174,6 +166,7 @@ injector.get('unknown');  // compile error — 'unknown' is not a registered key
 
 ### Out-of-Scope (deferred to Spec 008 or later)
 
+- **`angular.module()` global namespace** — Deferred to the dedicated AngularJS Compatibility Layer milestone, which wraps the ES module APIs from this spec under an `angular` constant for users migrating from classic AngularJS
 - **`service`, `provider`, `decorator` recipes** — Spec 008
 - **`config()` and `run()` blocks** — Spec 008
 - **Function parameter inference** — Not supported (explicit `$inject` or array-style only)

--- a/context/spec/007-dependency-injection-foundation/functional-spec.md
+++ b/context/spec/007-dependency-injection-foundation/functional-spec.md
@@ -1,0 +1,163 @@
+# Functional Specification: Dependency Injection — Foundation
+
+- **Roadmap Item:** Phase 1 — Core Runtime Foundation > Dependency Injection
+- **Status:** Draft
+- **Author:** Mgrdich
+
+---
+
+## 1. Overview and Rationale (The "Why")
+
+The framework currently has a standalone Scope module and Expression Parser, but no way to wire services together. Every subsequent module (the Compiler, HTTP, Forms, Routing) depends on having a dependency injection system to register and resolve services.
+
+**Problem:** Without DI, there is no way for modules to declare dependencies, no way to share instances across the application, and no way to build the rest of AngularJS — the entire framework is built on top of the injector.
+
+**Desired outcome:** A working module system and injector that supports registering values, constants, and factories; resolves dependencies using `$inject` property or array-style annotations; detects missing dependencies with clear error messages; and detects circular dependencies before they cause stack overflow. Everything must be fully type-safe with TypeScript inference where possible. This spec covers the foundation; `service`, `provider`, `decorator` recipes and `config`/`run` blocks are deferred to Spec 008.
+
+---
+
+## 2. Functional Requirements (The "What")
+
+### 2.1 Module Creation and Retrieval — Two API Styles
+
+Developers must be able to create and retrieve modules using **both** the classic `angular.module()` global pattern **and** modern ES module imports. Both APIs are first-class and share the same underlying module registry.
+
+**Classic AngularJS style:**
+
+- `angular.module('myApp', ['dep1', 'dep2'])` — creates a new module named `myApp` that depends on `dep1` and `dep2`
+- `angular.module('myApp')` — retrieves the existing module (no dependencies argument means retrieval, not creation)
+
+**Modern ES module style (named exports):**
+
+- `createModule('myApp', ['dep1', 'dep2'])` — creates a module
+- `getModule('myApp')` — retrieves an existing module
+
+Both APIs operate on the same module registry — a module created via `createModule` is retrievable via `angular.module` and vice versa.
+
+**Acceptance Criteria:**
+
+- [ ] `angular.module('app', [])` creates a new module named `app` with no dependencies
+- [ ] `angular.module('app', ['common'])` creates a module that depends on `common`
+- [ ] `angular.module('app')` (no dependencies arg) returns the previously created module
+- [ ] `angular.module('app')` throws a clear error if `app` was never created
+- [ ] Creating a module with the same name twice replaces the previous registration
+- [ ] `createModule()` and `getModule()` named exports work identically to `angular.module()`
+- [ ] Modules created via one API are retrievable via the other (shared registry)
+
+### 2.2 Module Dependency Graph
+
+Modules can depend on other modules. When a module is loaded, all its transitive dependencies are also loaded. Services registered in dependency modules are visible to the dependent module.
+
+**Acceptance Criteria:**
+
+- [ ] When `app` depends on `common`, services registered on `common` are available in `app`
+- [ ] Transitive dependencies work: if `app` depends on `b`, and `b` depends on `c`, services from `c` are visible in `app`
+- [ ] Each module is loaded only once, even if referenced by multiple modules in the graph
+- [ ] Missing module dependencies throw a clear error (e.g., `Module not found: 'common'`)
+
+### 2.3 Registering Services (value, constant, factory)
+
+Modules must provide methods to register services using three recipes:
+
+- `module.value(name, value)` — registers a plain value
+- `module.constant(name, value)` — registers a constant (available during config phase in Spec 008)
+- `module.factory(name, factoryFn)` — registers a factory function that returns the service instance. The factory function may declare dependencies.
+
+**Acceptance Criteria:**
+
+- [ ] `module.value('apiUrl', 'https://api.example.com')` registers a string value
+- [ ] `module.value('config', { timeout: 30 })` registers an object value
+- [ ] `module.constant('MAX_RETRIES', 3)` registers a constant
+- [ ] `module.factory('logger', () => ({ log: (msg) => console.log(msg) }))` registers a factory with no dependencies
+- [ ] `module.factory('userService', ['$http', ($http) => ({ ... })])` registers a factory with dependencies using array-style annotation
+- [ ] `module.factory('userService', userServiceFn)` with `userServiceFn.$inject = ['$http']` works using the `$inject` property
+
+### 2.4 Injector — get and has
+
+An injector must be created from a module (and its dependency graph). The injector provides methods to retrieve services and check their existence.
+
+- `injector.get(name)` — returns the instance of the named service
+- `injector.has(name)` — returns true if the service is registered, false otherwise
+
+**Acceptance Criteria:**
+
+- [ ] `injector.get('apiUrl')` returns the registered value
+- [ ] `injector.get('logger')` calls the factory function and returns its result
+- [ ] Services are singletons — `injector.get('logger') === injector.get('logger')` (same reference on every call)
+- [ ] `injector.has('apiUrl')` returns `true` for registered services
+- [ ] `injector.has('nonexistent')` returns `false`
+- [ ] `injector.get('nonexistent')` throws `Error('Unknown provider: nonexistent')`
+
+### 2.5 Injector — invoke and annotate
+
+The injector must be able to invoke arbitrary functions with their dependencies injected, and to annotate functions to extract their dependency list.
+
+- `injector.invoke(fn, self?, locals?)` — calls `fn` with its dependencies injected. Optional `self` for `this` binding, optional `locals` to override specific dependency resolutions.
+- `injector.annotate(fn)` — returns the array of dependency names declared on `fn` (via `$inject` or array-style)
+
+**Acceptance Criteria:**
+
+- [ ] `injector.invoke(['$http', ($http) => ...])` calls the function with `$http` injected
+- [ ] `injector.invoke(fn)` where `fn.$inject = ['$http']` also works
+- [ ] `injector.invoke(fn, self)` sets `this` to `self` inside `fn`
+- [ ] `injector.invoke(fn, null, { $http: mockHttp })` uses the mock instead of the registered `$http`
+- [ ] `injector.annotate(fn)` returns `['$http']` for both array-style and `$inject` annotated functions
+- [ ] `injector.annotate` throws a clear error if a function has no annotations (function parameter inference is not supported)
+
+### 2.6 Circular Dependency Detection
+
+If a service's factory function declares a dependency that (directly or transitively) depends back on the same service, the injector must detect the cycle and throw a clear error.
+
+**Acceptance Criteria:**
+
+- [ ] Direct cycle (`A` depends on `A`) throws `Error('Circular dependency: A <- A')`
+- [ ] Indirect cycle (`A` depends on `B`, `B` depends on `A`) throws `Error('Circular dependency: A <- B <- A')`
+- [ ] Deeper cycles (`A → B → C → A`) throw with the full dependency chain in the message
+
+### 2.7 Type Safety and Inference
+
+Every part of the DI system must be fully type-safe with proper TypeScript inference where possible. Consumers should get autocomplete, type checking, and compile-time errors for DI mistakes.
+
+**Key type-safety goals:**
+
+- **Typed service registration:** `module.value<T>(name, value)` infers `T` from the value argument, or accepts an explicit type parameter. Registered services have a known type.
+- **Typed injector.get:** `injector.get<T>(name)` returns `T`. Ideally, when a module's service registry is typed, `injector.get('logger')` infers the return type from the registration.
+- **Typed factories:** Factory functions have properly typed dependency parameters — `module.factory('userService', ['$http', ($http: HttpClient) => { ... }])` should type-check the `$http` parameter.
+- **$inject annotation:** The `$inject` property is typed as `readonly string[]`, and TypeScript should enforce that the annotated function's parameter count matches the `$inject` array length.
+- **No `any` leakage:** The internal injector implementation must use `unknown` instead of `any`, narrowing with type guards where needed.
+- **Generic constraints:** Where possible, use generic constraints to enforce that dependencies resolve to the correct types at the call site.
+
+**Acceptance Criteria:**
+
+- [ ] `module.value('apiUrl', 'https://...')` infers the value as `string`
+- [ ] `injector.get<HttpClient>('$http')` returns a typed `HttpClient`
+- [ ] `pnpm typecheck` passes with zero errors across the DI module
+- [ ] No use of `any` in the DI source code (except in deliberate, commented escape hatches at the annotation-parsing boundary if unavoidable)
+- [ ] All public APIs have explicit types for parameters and return values
+- [ ] Generic type parameters are used for type inference wherever they provide value (service registration, `invoke`, `get`)
+
+---
+
+## 3. Scope and Boundaries
+
+### In-Scope
+
+- Module system with **both** `angular.module()` (classic global) **and** `createModule()` / `getModule()` (modern ES imports) APIs
+- Shared module registry so both APIs are interchangeable
+- Module dependency graph (including transitive dependencies)
+- Three recipes: `value`, `constant`, `factory`
+- Injector with `get`, `has`, `invoke`, `annotate`
+- Two DI annotation styles: `$inject` property and array shorthand (function parameter inference is NOT supported)
+- Singleton instance caching
+- Clear errors for missing dependencies, missing modules, and circular dependencies
+- Full TypeScript type safety and inference across the entire DI surface
+- Comprehensive test suite
+
+### Out-of-Scope (deferred to Spec 008 or later)
+
+- **`service`, `provider`, `decorator` recipes** — Spec 008
+- **`config()` and `run()` blocks** — Spec 008
+- **Function parameter inference** — Not supported (explicit `$inject` or array-style only)
+- **$rootScope as a service** — A separate spec, integrates Scope with DI
+- **Expressions & Parser enhancements** — Phase 2
+- **Filters, Directives, HTTP, Forms, Routing, Animations** — Later phases

--- a/context/spec/007-dependency-injection-foundation/tasks.md
+++ b/context/spec/007-dependency-injection-foundation/tasks.md
@@ -5,15 +5,14 @@
 
 ---
 
-- [ ] **Slice 1: Module Registry & Creation APIs**
-  - [ ] Create `src/di/di-types.ts` with core type definitions: `Annotated`, `InvokableArray`, `Invokable`, `ModuleAPI<Registry>` (generic over a Registry type), `Injector<Registry>` (generic over a merged registry). Export as `type` exports. **[Agent: typescript-framework]**
-  - [ ] Create `src/di/module.ts` with a module-scoped `registry` Map, a `Module` class (minimal — just `name`, `requires`, `invokeQueue`), and a `resetRegistry()` test helper. **[Agent: typescript-framework]**
-  - [ ] Create `src/di/angular.ts` exporting named `createModule(name, requires)` and `getModule(name)` as the canonical implementation, plus an `angular` namespace object whose `module()` method is a **thin wrapper** that delegates to `createModule` / `getModule` (no duplicate logic). **[Agent: typescript-framework]**
-  - [ ] Create `src/di/__tests__/di.test.ts` with a `describe('Module creation', ...)` block. Tests: create module, retrieve module, throw on missing, both APIs share registry, replacing a module works, `angular.module` delegates to the same code path as `createModule`/`getModule`. Use `beforeEach(() => resetRegistry())` for test isolation. **[Agent: vitest-testing]**
-  - [ ] Create `src/di/index.ts` barrel exporting `angular`, `createModule`, `getModule`, and types. Verify: `pnpm test`, `pnpm typecheck`, `pnpm lint` pass. **[Agent: typescript-framework]**
+- [x] **Slice 1: Module Registry & Creation APIs**
+  - [x] Create `src/di/di-types.ts` with core type definitions: `Annotated`, `InvokableArray`, `Invokable`, `ModuleAPI<Registry>` (generic over a Registry type), `Injector<Registry>` (generic over a merged registry). Export as `type` exports. **[Agent: typescript-framework]**
+  - [x] Create `src/di/module.ts` with a module-scoped `registry` Map, a `Module` class (minimal — just `name`, `requires`, `invokeQueue`), `createModule(name, requires?)` and `getModule(name)` named exports, and a `resetRegistry()` test helper. **[Agent: typescript-framework]**
+  - [x] Create `src/di/__tests__/di.test.ts` with a `describe('createModule / getModule', ...)` block. Tests: create module, retrieve module, throw on missing, replacing a module works. Use `beforeEach(() => resetRegistry())` for test isolation. **[Agent: vitest-testing]**
+  - [x] Create `src/di/index.ts` barrel exporting `createModule`, `getModule`, and types. Verify: `pnpm test`, `pnpm typecheck`, `pnpm lint` pass. **[Agent: typescript-framework]**
 
 - [ ] **Slice 2: value/constant Registration & Basic Injector (no dependencies)**
-  - [ ] Add `value<Name extends string, T>(name: Name, value: T)` and `constant<Name, T>(name, value)` methods to the `Module` class using the builder pattern. Each returns `ModuleAPI<Registry & { [K in Name]: T }>` so the registry type widens with each call. At runtime the same instance is returned (cast through the new type). **[Agent: typescript-framework]**
+  - [x] Add `value<Name extends string, T>(name: Name, value: T)` and `constant<Name, T>(name, value)` methods to the `Module` class using the builder pattern. Each returns `ModuleAPI<Registry & { [K in Name]: T }>` so the registry type widens with each call. At runtime the same instance is returned (cast through the new type). **[Agent: typescript-framework]**
   - [ ] Create `src/di/injector.ts` with `createInjector(modules)` that loads modules from the registry, walks the (flat, no deps yet) invoke queue, and builds a `providerCache: Map<string, unknown>` for values/constants. Return an `Injector<Registry>` with overloaded `get<K extends keyof Registry>(name: K): Registry[K]` (typed) and `get<T>(name: string): T` (escape hatch), plus `has(name): boolean`. **[Agent: typescript-framework]**
   - [ ] Add runtime tests: `module.value('url', 'https://...')`, `module.constant('MAX', 3)`, `injector.get('url')`, `injector.has('url')`, `injector.get('unknown')` throws. **[Agent: vitest-testing]**
   - [ ] Add type-safety tests using `expectTypeOf` or `satisfies`: `injector.get('url')` infers `string`, `injector.get('MAX')` infers `number`, `injector.get('nonexistent')` is a **compile-time error** on a typed injector. **[Agent: vitest-testing]**
@@ -46,6 +45,6 @@
   - [ ] Verify: `pnpm test`, `pnpm typecheck`, `pnpm lint` pass. **[Agent: typescript-framework]**
 
 - [ ] **Slice 7: Public API Exports & Root Integration**
-  - [ ] Ensure `src/di/index.ts` exports everything: `angular`, `createModule`, `getModule`, `createInjector`, and all public types. Update `src/index.ts` to re-export from `./di/index`. **[Agent: typescript-framework]**
+  - [ ] Ensure `src/di/index.ts` exports everything: `createModule`, `getModule`, `createInjector`, and all public types. Update `src/index.ts` to re-export from `./di/index`. **[Agent: typescript-framework]**
   - [ ] Verify build: run `pnpm build`, check that `dist/esm/di/index.mjs`, `dist/cjs/di/index.cjs`, and `dist/types/di/index.d.ts` are all generated. **[Agent: rollup-build]**
   - [ ] Final verification: `pnpm lint`, `pnpm typecheck`, `pnpm test`, `pnpm build` all pass. **[Agent: typescript-framework]**

--- a/context/spec/007-dependency-injection-foundation/tasks.md
+++ b/context/spec/007-dependency-injection-foundation/tasks.md
@@ -6,27 +6,32 @@
 ---
 
 - [ ] **Slice 1: Module Registry & Creation APIs**
-  - [ ] Create `src/di/di-types.ts` with core type definitions: `Annotated`, `InvokableArray`, `Invokable`, `ModuleAPI`, `Injector`. Export them as `type` exports. **[Agent: typescript-framework]**
+  - [ ] Create `src/di/di-types.ts` with core type definitions: `Annotated`, `InvokableArray`, `Invokable`, `ModuleAPI<Registry>` (generic over a Registry type), `Injector<Registry>` (generic over a merged registry). Export as `type` exports. **[Agent: typescript-framework]**
   - [ ] Create `src/di/module.ts` with a module-scoped `registry` Map, a `Module` class (minimal — just `name`, `requires`, `invokeQueue`), and a `resetRegistry()` test helper. **[Agent: typescript-framework]**
-  - [ ] Create `src/di/angular.ts` exporting the `angular` namespace object with a `module(name, requires?)` method, plus named exports `createModule(name, requires)` and `getModule(name)`. Both APIs share the same registry. **[Agent: typescript-framework]**
-  - [ ] Create `src/di/__tests__/di.test.ts` with a `describe('Module creation', ...)` block. Tests: create module, retrieve module, throw on missing, both APIs share registry, replacing a module works. Use `beforeEach(() => resetRegistry())` for test isolation. **[Agent: vitest-testing]**
+  - [ ] Create `src/di/angular.ts` exporting named `createModule(name, requires)` and `getModule(name)` as the canonical implementation, plus an `angular` namespace object whose `module()` method is a **thin wrapper** that delegates to `createModule` / `getModule` (no duplicate logic). **[Agent: typescript-framework]**
+  - [ ] Create `src/di/__tests__/di.test.ts` with a `describe('Module creation', ...)` block. Tests: create module, retrieve module, throw on missing, both APIs share registry, replacing a module works, `angular.module` delegates to the same code path as `createModule`/`getModule`. Use `beforeEach(() => resetRegistry())` for test isolation. **[Agent: vitest-testing]**
   - [ ] Create `src/di/index.ts` barrel exporting `angular`, `createModule`, `getModule`, and types. Verify: `pnpm test`, `pnpm typecheck`, `pnpm lint` pass. **[Agent: typescript-framework]**
 
 - [ ] **Slice 2: value/constant Registration & Basic Injector (no dependencies)**
-  - [ ] Add `value<T>(name, value)` and `constant<T>(name, value)` methods to the `Module` class. They push to the `invokeQueue`. Ensure types use generic `T` for value inference. **[Agent: typescript-framework]**
-  - [ ] Create `src/di/injector.ts` with `createInjector(moduleNames: string[])` that loads modules from the registry, walks the (flat, no deps yet) invoke queue, and builds a `providerCache: Map<string, unknown>` for values/constants. Return an `Injector` with `get<T>(name): T` and `has(name): boolean`. **[Agent: typescript-framework]**
-  - [ ] Add tests: `module.value('url', 'https://...')`, `module.constant('MAX', 3)`, `injector.get('url')`, `injector.has('url')`, `injector.get('unknown')` throws `'Unknown provider: unknown'`. **[Agent: vitest-testing]**
+  - [ ] Add `value<Name extends string, T>(name: Name, value: T)` and `constant<Name, T>(name, value)` methods to the `Module` class using the builder pattern. Each returns `ModuleAPI<Registry & { [K in Name]: T }>` so the registry type widens with each call. At runtime the same instance is returned (cast through the new type). **[Agent: typescript-framework]**
+  - [ ] Create `src/di/injector.ts` with `createInjector(modules)` that loads modules from the registry, walks the (flat, no deps yet) invoke queue, and builds a `providerCache: Map<string, unknown>` for values/constants. Return an `Injector<Registry>` with overloaded `get<K extends keyof Registry>(name: K): Registry[K]` (typed) and `get<T>(name: string): T` (escape hatch), plus `has(name): boolean`. **[Agent: typescript-framework]**
+  - [ ] Add runtime tests: `module.value('url', 'https://...')`, `module.constant('MAX', 3)`, `injector.get('url')`, `injector.has('url')`, `injector.get('unknown')` throws. **[Agent: vitest-testing]**
+  - [ ] Add type-safety tests using `expectTypeOf` or `satisfies`: `injector.get('url')` infers `string`, `injector.get('MAX')` infers `number`, `injector.get('nonexistent')` is a **compile-time error** on a typed injector. **[Agent: vitest-testing]**
   - [ ] Update `src/di/index.ts` to export `createInjector`. Verify: `pnpm test`, `pnpm typecheck`, `pnpm lint` pass. **[Agent: typescript-framework]**
 
 - [ ] **Slice 3: Module Dependency Graph**
   - [ ] Update `createInjector` to walk the dependency graph: given `['app']`, recursively load `app.requires` modules, then their requires, etc. Track loaded modules in a `Set<string>` to handle shared deps (load once). Throw `'Module not found: <name>'` for missing modules. **[Agent: typescript-framework]**
-  - [ ] Add tests: module `app` depends on `common`, service registered on `common` is visible in `app`. Transitive: `app → b → c`. Shared dep loaded once. Missing module throws. **[Agent: vitest-testing]**
+  - [ ] Add a `MergeRegistries` utility type that merges the typed registries of multiple modules. The injector built from several modules should have a combined registry type so `get('nameFromDep')` also has compile-time type inference. **[Agent: typescript-framework]**
+  - [ ] Add runtime tests: module `app` depends on `common`, service registered on `common` is visible in `app`. Transitive: `app → b → c`. Shared dep loaded once. Missing module throws. **[Agent: vitest-testing]**
+  - [ ] Add type-safety tests: services registered in a dependency module appear in the consuming module's typed registry (`get('serviceFromCommon')` infers the correct type). **[Agent: vitest-testing]**
   - [ ] Verify: `pnpm test`, `pnpm typecheck`, `pnpm lint` pass. **[Agent: typescript-framework]**
 
 - [ ] **Slice 4: factory Recipe with Dependency Injection**
   - [ ] Create `src/di/annotate.ts` with an `annotate(fn: Invokable): readonly string[]` helper. If `fn` is an array, split into `[...deps, actualFn]`. Else read `fn.$inject`. Throw clear error if neither. **[Agent: typescript-framework]**
-  - [ ] Add `factory(name, invokable)` method to the `Module` class. In `createInjector`, update provider resolution: factories are lazy — store the invokable, resolve dependencies on first `get(name)`, cache the result for singleton behavior. **[Agent: typescript-framework]**
-  - [ ] Add tests: factory with no deps, factory with `$inject` property, factory with array-style annotation, singleton caching (`get` returns same reference), factory accessing a `value` dependency. **[Agent: vitest-testing]**
+  - [ ] Add `factory<Name extends string, T>(name: Name, invokable)` method to the `Module` class using the same builder pattern — returns `ModuleAPI<Registry & { [K in Name]: T }>`. The factory's return type `T` should be inferable from the invokable's return type when possible. **[Agent: typescript-framework]**
+  - [ ] In `createInjector`, update provider resolution: factories are lazy — store the invokable, resolve dependencies on first `get(name)`, cache the result for singleton behavior. **[Agent: typescript-framework]**
+  - [ ] Add runtime tests: factory with no deps, factory with `$inject` property, factory with array-style annotation, singleton caching, factory accessing a `value` dependency. **[Agent: vitest-testing]**
+  - [ ] Add type-safety tests: `.factory('logger', () => ({ log: ... }))` — `injector.get('logger')` infers `{ log: ... }`. **[Agent: vitest-testing]**
   - [ ] Verify: `pnpm test`, `pnpm typecheck`, `pnpm lint` pass. **[Agent: typescript-framework]**
 
 - [ ] **Slice 5: Injector.invoke and Injector.annotate**

--- a/context/spec/007-dependency-injection-foundation/tasks.md
+++ b/context/spec/007-dependency-injection-foundation/tasks.md
@@ -1,0 +1,46 @@
+# Tasks: Dependency Injection — Foundation
+
+- **Specification:** `context/spec/007-dependency-injection-foundation/`
+- **Status:** Not Started
+
+---
+
+- [ ] **Slice 1: Module Registry & Creation APIs**
+  - [ ] Create `src/di/di-types.ts` with core type definitions: `Annotated`, `InvokableArray`, `Invokable`, `ModuleAPI`, `Injector`. Export them as `type` exports. **[Agent: typescript-framework]**
+  - [ ] Create `src/di/module.ts` with a module-scoped `registry` Map, a `Module` class (minimal — just `name`, `requires`, `invokeQueue`), and a `resetRegistry()` test helper. **[Agent: typescript-framework]**
+  - [ ] Create `src/di/angular.ts` exporting the `angular` namespace object with a `module(name, requires?)` method, plus named exports `createModule(name, requires)` and `getModule(name)`. Both APIs share the same registry. **[Agent: typescript-framework]**
+  - [ ] Create `src/di/__tests__/di.test.ts` with a `describe('Module creation', ...)` block. Tests: create module, retrieve module, throw on missing, both APIs share registry, replacing a module works. Use `beforeEach(() => resetRegistry())` for test isolation. **[Agent: vitest-testing]**
+  - [ ] Create `src/di/index.ts` barrel exporting `angular`, `createModule`, `getModule`, and types. Verify: `pnpm test`, `pnpm typecheck`, `pnpm lint` pass. **[Agent: typescript-framework]**
+
+- [ ] **Slice 2: value/constant Registration & Basic Injector (no dependencies)**
+  - [ ] Add `value<T>(name, value)` and `constant<T>(name, value)` methods to the `Module` class. They push to the `invokeQueue`. Ensure types use generic `T` for value inference. **[Agent: typescript-framework]**
+  - [ ] Create `src/di/injector.ts` with `createInjector(moduleNames: string[])` that loads modules from the registry, walks the (flat, no deps yet) invoke queue, and builds a `providerCache: Map<string, unknown>` for values/constants. Return an `Injector` with `get<T>(name): T` and `has(name): boolean`. **[Agent: typescript-framework]**
+  - [ ] Add tests: `module.value('url', 'https://...')`, `module.constant('MAX', 3)`, `injector.get('url')`, `injector.has('url')`, `injector.get('unknown')` throws `'Unknown provider: unknown'`. **[Agent: vitest-testing]**
+  - [ ] Update `src/di/index.ts` to export `createInjector`. Verify: `pnpm test`, `pnpm typecheck`, `pnpm lint` pass. **[Agent: typescript-framework]**
+
+- [ ] **Slice 3: Module Dependency Graph**
+  - [ ] Update `createInjector` to walk the dependency graph: given `['app']`, recursively load `app.requires` modules, then their requires, etc. Track loaded modules in a `Set<string>` to handle shared deps (load once). Throw `'Module not found: <name>'` for missing modules. **[Agent: typescript-framework]**
+  - [ ] Add tests: module `app` depends on `common`, service registered on `common` is visible in `app`. Transitive: `app → b → c`. Shared dep loaded once. Missing module throws. **[Agent: vitest-testing]**
+  - [ ] Verify: `pnpm test`, `pnpm typecheck`, `pnpm lint` pass. **[Agent: typescript-framework]**
+
+- [ ] **Slice 4: factory Recipe with Dependency Injection**
+  - [ ] Create `src/di/annotate.ts` with an `annotate(fn: Invokable): readonly string[]` helper. If `fn` is an array, split into `[...deps, actualFn]`. Else read `fn.$inject`. Throw clear error if neither. **[Agent: typescript-framework]**
+  - [ ] Add `factory(name, invokable)` method to the `Module` class. In `createInjector`, update provider resolution: factories are lazy — store the invokable, resolve dependencies on first `get(name)`, cache the result for singleton behavior. **[Agent: typescript-framework]**
+  - [ ] Add tests: factory with no deps, factory with `$inject` property, factory with array-style annotation, singleton caching (`get` returns same reference), factory accessing a `value` dependency. **[Agent: vitest-testing]**
+  - [ ] Verify: `pnpm test`, `pnpm typecheck`, `pnpm lint` pass. **[Agent: typescript-framework]**
+
+- [ ] **Slice 5: Injector.invoke and Injector.annotate**
+  - [ ] Add `invoke<T>(fn: Invokable, self?: unknown, locals?: Record<string, unknown>): T` to the `Injector`. Use `annotate()` to get dep names, resolve each via `get()` or `locals[name]` if provided, call the function with `self` as `this`. **[Agent: typescript-framework]**
+  - [ ] Add `annotate(fn)` method on `Injector` that delegates to the `annotate` helper. **[Agent: typescript-framework]**
+  - [ ] Add tests: `invoke` with array-style, `invoke` with `$inject`, `invoke` with `self` binding, `invoke` with `locals` override, `invoke` with unannotated function throws, `annotate` returns dep names. **[Agent: vitest-testing]**
+  - [ ] Verify: `pnpm test`, `pnpm typecheck`, `pnpm lint` pass. **[Agent: typescript-framework]**
+
+- [ ] **Slice 6: Circular Dependency Detection**
+  - [ ] Update `createInjector`'s factory resolution to track a resolution path stack (`Array<string>`). Before resolving a service, check if its name is already in the stack. If yes, throw `'Circular dependency: A <- B <- A'` with the full chain. Push before resolving, pop after. **[Agent: typescript-framework]**
+  - [ ] Add tests: direct cycle (`A` depends on `A`), 2-level cycle (`A → B → A`), 3-level cycle (`A → B → C → A`). Error message includes the full chain. **[Agent: vitest-testing]**
+  - [ ] Verify: `pnpm test`, `pnpm typecheck`, `pnpm lint` pass. **[Agent: typescript-framework]**
+
+- [ ] **Slice 7: Public API Exports & Root Integration**
+  - [ ] Ensure `src/di/index.ts` exports everything: `angular`, `createModule`, `getModule`, `createInjector`, and all public types. Update `src/index.ts` to re-export from `./di/index`. **[Agent: typescript-framework]**
+  - [ ] Verify build: run `pnpm build`, check that `dist/esm/di/index.mjs`, `dist/cjs/di/index.cjs`, and `dist/types/di/index.d.ts` are all generated. **[Agent: rollup-build]**
+  - [ ] Final verification: `pnpm lint`, `pnpm typecheck`, `pnpm test`, `pnpm build` all pass. **[Agent: typescript-framework]**

--- a/context/spec/007-dependency-injection-foundation/tasks.md
+++ b/context/spec/007-dependency-injection-foundation/tasks.md
@@ -35,7 +35,7 @@
 
 - [ ] **Slice 5: Injector.invoke and Injector.annotate**
   - [x] Add `invoke<T>(fn: Invokable, self?: unknown, locals?: Record<string, unknown>): T` to the `Injector`. Use `annotate()` to get dep names, resolve each via `get()` or `locals[name]` if provided, call the function with `self` as `this`. **[Agent: typescript-framework]**
-  - [ ] Add `annotate(fn)` method on `Injector` that delegates to the `annotate` helper. **[Agent: typescript-framework]**
+  - [x] Add `annotate(fn)` method on `Injector` that delegates to the `annotate` helper. **[Agent: typescript-framework]**
   - [ ] Add tests: `invoke` with array-style, `invoke` with `$inject`, `invoke` with `self` binding, `invoke` with `locals` override, `invoke` with unannotated function throws, `annotate` returns dep names. **[Agent: vitest-testing]**
   - [ ] Verify: `pnpm test`, `pnpm typecheck`, `pnpm lint` pass. **[Agent: typescript-framework]**
 

--- a/context/spec/007-dependency-injection-foundation/tasks.md
+++ b/context/spec/007-dependency-injection-foundation/tasks.md
@@ -11,30 +11,30 @@
   - [x] Create `src/di/__tests__/di.test.ts` with a `describe('createModule / getModule', ...)` block. Tests: create module, retrieve module, throw on missing, replacing a module works. Use `beforeEach(() => resetRegistry())` for test isolation. **[Agent: vitest-testing]**
   - [x] Create `src/di/index.ts` barrel exporting `createModule`, `getModule`, and types. Verify: `pnpm test`, `pnpm typecheck`, `pnpm lint` pass. **[Agent: typescript-framework]**
 
-- [ ] **Slice 2: value/constant Registration & Basic Injector (no dependencies)**
+- [x] **Slice 2: value/constant Registration & Basic Injector (no dependencies)**
   - [x] Add `value<Name extends string, T>(name: Name, value: T)` and `constant<Name, T>(name, value)` methods to the `Module` class using the builder pattern. Each returns `ModuleAPI<Registry & { [K in Name]: T }>` so the registry type widens with each call. At runtime the same instance is returned (cast through the new type). **[Agent: typescript-framework]**
-  - [ ] Create `src/di/injector.ts` with `createInjector(modules)` that loads modules from the registry, walks the (flat, no deps yet) invoke queue, and builds a `providerCache: Map<string, unknown>` for values/constants. Return an `Injector<Registry>` with overloaded `get<K extends keyof Registry>(name: K): Registry[K]` (typed) and `get<T>(name: string): T` (escape hatch), plus `has(name): boolean`. **[Agent: typescript-framework]**
-  - [ ] Add runtime tests: `module.value('url', 'https://...')`, `module.constant('MAX', 3)`, `injector.get('url')`, `injector.has('url')`, `injector.get('unknown')` throws. **[Agent: vitest-testing]**
-  - [ ] Add type-safety tests using `expectTypeOf` or `satisfies`: `injector.get('url')` infers `string`, `injector.get('MAX')` infers `number`, `injector.get('nonexistent')` is a **compile-time error** on a typed injector. **[Agent: vitest-testing]**
-  - [ ] Update `src/di/index.ts` to export `createInjector`. Verify: `pnpm test`, `pnpm typecheck`, `pnpm lint` pass. **[Agent: typescript-framework]**
+  - [x] Create `src/di/injector.ts` with `createInjector(modules)` that loads modules from the registry, walks the (flat, no deps yet) invoke queue, and builds a `providerCache: Map<string, unknown>` for values/constants. Return an `Injector<Registry>` with overloaded `get<K extends keyof Registry>(name: K): Registry[K]` (typed) and `get<T>(name: string): T` (escape hatch), plus `has(name): boolean`. **[Agent: typescript-framework]**
+  - [x] Add runtime tests: `module.value('url', 'https://...')`, `module.constant('MAX', 3)`, `injector.get('url')`, `injector.has('url')`, `injector.get('unknown')` throws. **[Agent: vitest-testing]**
+  - [x] Add type-safety tests using `expectTypeOf` or `satisfies`: `injector.get('url')` infers `string`, `injector.get('MAX')` infers `number`, `injector.get('nonexistent')` is a **compile-time error** on a typed injector. **[Agent: vitest-testing]**
+  - [x] Update `src/di/index.ts` to export `createInjector`. Verify: `pnpm test`, `pnpm typecheck`, `pnpm lint` pass. **[Agent: typescript-framework]**
 
-- [ ] **Slice 3: Module Dependency Graph**
-  - [ ] Update `createInjector` to walk the dependency graph: given `['app']`, recursively load `app.requires` modules, then their requires, etc. Track loaded modules in a `Set<string>` to handle shared deps (load once). Throw `'Module not found: <name>'` for missing modules. **[Agent: typescript-framework]**
-  - [ ] Add a `MergeRegistries` utility type that merges the typed registries of multiple modules. The injector built from several modules should have a combined registry type so `get('nameFromDep')` also has compile-time type inference. **[Agent: typescript-framework]**
-  - [ ] Add runtime tests: module `app` depends on `common`, service registered on `common` is visible in `app`. Transitive: `app → b → c`. Shared dep loaded once. Missing module throws. **[Agent: vitest-testing]**
-  - [ ] Add type-safety tests: services registered in a dependency module appear in the consuming module's typed registry (`get('serviceFromCommon')` infers the correct type). **[Agent: vitest-testing]**
-  - [ ] Verify: `pnpm test`, `pnpm typecheck`, `pnpm lint` pass. **[Agent: typescript-framework]**
+- [x] **Slice 3: Module Dependency Graph**
+  - [x] Update `createInjector` to walk the dependency graph: given `['app']`, recursively load `app.requires` modules, then their requires, etc. Track loaded modules in a `Set<string>` to handle shared deps (load once). Throw `'Module not found: <name>'` for missing modules. **[Agent: typescript-framework]**
+  - [x] Add a `MergeRegistries` utility type that merges the typed registries of multiple modules. The injector built from several modules should have a combined registry type so `get('nameFromDep')` also has compile-time type inference. **[Agent: typescript-framework]**
+  - [x] Add runtime tests: module `app` depends on `common`, service registered on `common` is visible in `app`. Transitive: `app → b → c`. Shared dep loaded once. Missing module throws. **[Agent: vitest-testing]**
+  - [x] Add type-safety tests: services registered in a dependency module appear in the consuming module's typed registry (`get('serviceFromCommon')` infers the correct type). **[Agent: vitest-testing]**
+  - [x] Verify: `pnpm test`, `pnpm typecheck`, `pnpm lint` pass. **[Agent: typescript-framework]**
 
-- [ ] **Slice 4: factory Recipe with Dependency Injection**
-  - [ ] Create `src/di/annotate.ts` with an `annotate(fn: Invokable): readonly string[]` helper. If `fn` is an array, split into `[...deps, actualFn]`. Else read `fn.$inject`. Throw clear error if neither. **[Agent: typescript-framework]**
-  - [ ] Add `factory<Name extends string, T>(name: Name, invokable)` method to the `Module` class using the same builder pattern — returns `ModuleAPI<Registry & { [K in Name]: T }>`. The factory's return type `T` should be inferable from the invokable's return type when possible. **[Agent: typescript-framework]**
-  - [ ] In `createInjector`, update provider resolution: factories are lazy — store the invokable, resolve dependencies on first `get(name)`, cache the result for singleton behavior. **[Agent: typescript-framework]**
-  - [ ] Add runtime tests: factory with no deps, factory with `$inject` property, factory with array-style annotation, singleton caching, factory accessing a `value` dependency. **[Agent: vitest-testing]**
-  - [ ] Add type-safety tests: `.factory('logger', () => ({ log: ... }))` — `injector.get('logger')` infers `{ log: ... }`. **[Agent: vitest-testing]**
-  - [ ] Verify: `pnpm test`, `pnpm typecheck`, `pnpm lint` pass. **[Agent: typescript-framework]**
+- [x] **Slice 4: factory Recipe with Dependency Injection**
+  - [x] Create `src/di/annotate.ts` with an `annotate(fn: Invokable): readonly string[]` helper. If `fn` is an array, split into `[...deps, actualFn]`. Else read `fn.$inject`. Throw clear error if neither. **[Agent: typescript-framework]**
+  - [x] Add `factory<Name extends string, T>(name: Name, invokable)` method to the `Module` class using the same builder pattern — returns `ModuleAPI<Registry & { [K in Name]: T }>`. The factory's return type `T` should be inferable from the invokable's return type when possible. **[Agent: typescript-framework]**
+  - [x] In `createInjector`, update provider resolution: factories are lazy — store the invokable, resolve dependencies on first `get(name)`, cache the result for singleton behavior. **[Agent: typescript-framework]**
+  - [x] Add runtime tests: factory with no deps, factory with `$inject` property, factory with array-style annotation, singleton caching, factory accessing a `value` dependency. **[Agent: vitest-testing]**
+  - [x] Add type-safety tests: `.factory('logger', () => ({ log: ... }))` — `injector.get('logger')` infers `{ log: ... }`. **[Agent: vitest-testing]**
+  - [x] Verify: `pnpm test`, `pnpm typecheck`, `pnpm lint` pass. **[Agent: typescript-framework]**
 
 - [ ] **Slice 5: Injector.invoke and Injector.annotate**
-  - [ ] Add `invoke<T>(fn: Invokable, self?: unknown, locals?: Record<string, unknown>): T` to the `Injector`. Use `annotate()` to get dep names, resolve each via `get()` or `locals[name]` if provided, call the function with `self` as `this`. **[Agent: typescript-framework]**
+  - [x] Add `invoke<T>(fn: Invokable, self?: unknown, locals?: Record<string, unknown>): T` to the `Injector`. Use `annotate()` to get dep names, resolve each via `get()` or `locals[name]` if provided, call the function with `self` as `this`. **[Agent: typescript-framework]**
   - [ ] Add `annotate(fn)` method on `Injector` that delegates to the `annotate` helper. **[Agent: typescript-framework]**
   - [ ] Add tests: `invoke` with array-style, `invoke` with `$inject`, `invoke` with `self` binding, `invoke` with `locals` override, `invoke` with unannotated function throws, `annotate` returns dep names. **[Agent: vitest-testing]**
   - [ ] Verify: `pnpm test`, `pnpm typecheck`, `pnpm lint` pass. **[Agent: typescript-framework]**

--- a/context/spec/007-dependency-injection-foundation/tasks.md
+++ b/context/spec/007-dependency-injection-foundation/tasks.md
@@ -1,7 +1,7 @@
 # Tasks: Dependency Injection — Foundation
 
 - **Specification:** `context/spec/007-dependency-injection-foundation/`
-- **Status:** Not Started
+- **Status:** Complete
 
 ---
 
@@ -39,12 +39,12 @@
   - [x] Add tests: `invoke` with array-style, `invoke` with `$inject`, `invoke` with `self` binding, `invoke` with `locals` override, `invoke` with unannotated function throws, `annotate` returns dep names. **[Agent: vitest-testing]**
   - [x] Verify: `pnpm test`, `pnpm typecheck`, `pnpm lint` pass. **[Agent: typescript-framework]**
 
-- [ ] **Slice 6: Circular Dependency Detection**
-  - [ ] Update `createInjector`'s factory resolution to track a resolution path stack (`Array<string>`). Before resolving a service, check if its name is already in the stack. If yes, throw `'Circular dependency: A <- B <- A'` with the full chain. Push before resolving, pop after. **[Agent: typescript-framework]**
-  - [ ] Add tests: direct cycle (`A` depends on `A`), 2-level cycle (`A → B → A`), 3-level cycle (`A → B → C → A`). Error message includes the full chain. **[Agent: vitest-testing]**
-  - [ ] Verify: `pnpm test`, `pnpm typecheck`, `pnpm lint` pass. **[Agent: typescript-framework]**
+- [x] **Slice 6: Circular Dependency Detection**
+  - [x] Update `createInjector`'s factory resolution to track a resolution path stack (`Array<string>`). Before resolving a service, check if its name is already in the stack. If yes, throw `'Circular dependency: A <- B <- A'` with the full chain. Push before resolving, pop after. **[Agent: typescript-framework]**
+  - [x] Add tests: direct cycle (`A` depends on `A`), 2-level cycle (`A → B → A`), 3-level cycle (`A → B → C → A`). Error message includes the full chain. **[Agent: vitest-testing]**
+  - [x] Verify: `pnpm test`, `pnpm typecheck`, `pnpm lint` pass. **[Agent: typescript-framework]**
 
-- [ ] **Slice 7: Public API Exports & Root Integration**
-  - [ ] Ensure `src/di/index.ts` exports everything: `createModule`, `getModule`, `createInjector`, and all public types. Update `src/index.ts` to re-export from `./di/index`. **[Agent: typescript-framework]**
-  - [ ] Verify build: run `pnpm build`, check that `dist/esm/di/index.mjs`, `dist/cjs/di/index.cjs`, and `dist/types/di/index.d.ts` are all generated. **[Agent: rollup-build]**
-  - [ ] Final verification: `pnpm lint`, `pnpm typecheck`, `pnpm test`, `pnpm build` all pass. **[Agent: typescript-framework]**
+- [x] **Slice 7: Public API Exports & Root Integration**
+  - [x] Ensure `src/di/index.ts` exports everything: `createModule`, `getModule`, `createInjector`, and all public types. Update `src/index.ts` to re-export from `./di/index`. **[Agent: typescript-framework]**
+  - [x] Verify build: run `pnpm build`, check that `dist/esm/di/index.mjs`, `dist/cjs/di/index.cjs`, and `dist/types/di/index.d.ts` are all generated. **[Agent: rollup-build]**
+  - [x] Final verification: `pnpm lint`, `pnpm typecheck`, `pnpm test`, `pnpm build` all pass. **[Agent: typescript-framework]**

--- a/context/spec/007-dependency-injection-foundation/tasks.md
+++ b/context/spec/007-dependency-injection-foundation/tasks.md
@@ -33,11 +33,11 @@
   - [x] Add type-safety tests: `.factory('logger', () => ({ log: ... }))` — `injector.get('logger')` infers `{ log: ... }`. **[Agent: vitest-testing]**
   - [x] Verify: `pnpm test`, `pnpm typecheck`, `pnpm lint` pass. **[Agent: typescript-framework]**
 
-- [ ] **Slice 5: Injector.invoke and Injector.annotate**
+- [x] **Slice 5: Injector.invoke and Injector.annotate**
   - [x] Add `invoke<T>(fn: Invokable, self?: unknown, locals?: Record<string, unknown>): T` to the `Injector`. Use `annotate()` to get dep names, resolve each via `get()` or `locals[name]` if provided, call the function with `self` as `this`. **[Agent: typescript-framework]**
   - [x] Add `annotate(fn)` method on `Injector` that delegates to the `annotate` helper. **[Agent: typescript-framework]**
-  - [ ] Add tests: `invoke` with array-style, `invoke` with `$inject`, `invoke` with `self` binding, `invoke` with `locals` override, `invoke` with unannotated function throws, `annotate` returns dep names. **[Agent: vitest-testing]**
-  - [ ] Verify: `pnpm test`, `pnpm typecheck`, `pnpm lint` pass. **[Agent: typescript-framework]**
+  - [x] Add tests: `invoke` with array-style, `invoke` with `$inject`, `invoke` with `self` binding, `invoke` with `locals` override, `invoke` with unannotated function throws, `annotate` returns dep names. **[Agent: vitest-testing]**
+  - [x] Verify: `pnpm test`, `pnpm typecheck`, `pnpm lint` pass. **[Agent: typescript-framework]**
 
 - [ ] **Slice 6: Circular Dependency Detection**
   - [ ] Update `createInjector`'s factory resolution to track a resolution path stack (`Array<string>`). Before resolving a service, check if its name is already in the stack. If yes, throw `'Circular dependency: A <- B <- A'` with the full chain. Push before resolving, pop after. **[Agent: typescript-framework]**

--- a/context/spec/007-dependency-injection-foundation/technical-considerations.md
+++ b/context/spec/007-dependency-injection-foundation/technical-considerations.md
@@ -11,10 +11,10 @@
 Build the DI system as a new module under `src/di/`. The module has three main pieces:
 
 1. **Module registry** — A singleton `Map<string, Module>` that stores all modules by name. Both `angular.module()` and `createModule()` read/write this same registry, so the APIs are interchangeable.
-2. **Module class** — Holds the queued service registrations (`value`, `constant`, `factory`) as a list of invokables. Registration is *declarative* — nothing is instantiated until the injector is created.
-3. **Injector** — Created from a root module name. Walks the dependency graph, collects all queued registrations, and provides `get`, `has`, `invoke`, `annotate` for resolving services. Uses lazy instantiation with a cache for singletons.
+2. **Module class** — Generic over a `Registry` type parameter that tracks all registered services as a mapped type `{ [K in registered name]: service type }`. Each `.value()` / `.constant()` / `.factory()` call returns `Module<Registry & { [newName]: newType }>` — a builder-pattern approach that accumulates type information across chained calls. Registration is *declarative* — nothing is instantiated until the injector is created.
+3. **Injector** — Created from a root module. Walks the dependency graph, collects all queued registrations, and provides `get`, `has`, `invoke`, `annotate` for resolving services. Uses lazy instantiation with a cache for singletons. The injector type is generic over the merged registry of all modules in the graph, so `injector.get('name')` infers the correct return type from string literal lookup.
 
-The `angular` namespace is a named export that provides the `module()` method. It is NOT a default export or a global — consumers import it explicitly (`import { angular } from 'my-own-angularjs/di'`).
+The `angular` namespace is a **thin wrapper** over `createModule` / `getModule` — `angular.module(name, requires)` literally calls `createModule(name, requires)` and `angular.module(name)` calls `getModule(name)`. There is ONE implementation; `angular` just provides a familiar surface for users migrating from classic AngularJS. The `angular` namespace is a named export that consumers import explicitly (`import { angular } from 'my-own-angularjs/di'`).
 
 No architectural changes. The new module plugs into existing `src/di/` (currently empty) and extends `src/di/index.ts` as a barrel.
 
@@ -65,22 +65,44 @@ type Annotated<Fn extends (...args: unknown[]) => unknown> = Fn & {
 type InvokableArray = readonly [...string[], (...deps: unknown[]) => unknown];
 type Invokable = Annotated<(...args: unknown[]) => unknown> | InvokableArray;
 
-// Module API
-interface ModuleAPI {
+// Module API — generic over a Registry type that accumulates
+// registered services via builder-pattern return types.
+interface ModuleAPI<Registry extends Record<string, unknown> = {}> {
   readonly name: string;
   readonly requires: readonly string[];
-  value<T>(name: string, value: T): ModuleAPI;
-  constant<T>(name: string, value: T): ModuleAPI;
-  factory(name: string, factory: Invokable): ModuleAPI;
+
+  // Each call returns a NEW ModuleAPI type with the additional service merged
+  // into the registry. TypeScript infers `Name` as a string literal from the
+  // argument, and `T` from the value argument.
+  value<Name extends string, T>(
+    name: Name,
+    value: T,
+  ): ModuleAPI<Registry & { [K in Name]: T }>;
+
+  constant<Name extends string, T>(
+    name: Name,
+    value: T,
+  ): ModuleAPI<Registry & { [K in Name]: T }>;
+
+  factory<Name extends string, T>(
+    name: Name,
+    factory: Invokable,
+  ): ModuleAPI<Registry & { [K in Name]: T }>;
 }
 
-// Injector API
-interface Injector {
-  get<T = unknown>(name: string): T;
+// Injector API — generic over the merged registry of all modules it was built
+// from. `get` uses the registry for type inference; an explicit generic is
+// still supported as a fallback escape hatch.
+interface Injector<Registry extends Record<string, unknown> = Record<string, unknown>> {
+  get<K extends keyof Registry>(name: K): Registry[K];
+  get<T>(name: string): T; // overload for escape hatch
   has(name: string): boolean;
   invoke<T = unknown>(fn: Invokable, self?: unknown, locals?: Record<string, unknown>): T;
   annotate(fn: Invokable): readonly string[];
 }
+
+// Helper type to merge registries from multiple modules in dependency order.
+type MergeRegistries<Modules extends readonly ModuleAPI<any>[]> = /* ... */;
 ```
 
 ### Key Implementation Details
@@ -94,7 +116,9 @@ interface Injector {
 | Resolution path stack | `Array<string>` tracking in-progress resolutions for cycle detection                                                        |
 | `annotate`            | If `fn` is an array, pop last element as the actual fn and use rest as `$inject`. Else read `fn.$inject`. Throw if neither. |
 | Error messages        | `Unknown provider: <name>`, `Module not found: <name>`, `Circular dependency: A <- B <- A`                                  |
-| `angular` namespace   | Object with `module(name, requires?)` method; same signature/behavior as `createModule` / `getModule`                       |
+| `angular` namespace   | **Thin wrapper.** `angular.module(name, requires)` is literally `(name, requires) => requires !== undefined ? createModule(name, requires) : getModule(name)`. One shared implementation. |
+| Builder-pattern types | `value` / `constant` / `factory` methods return `ModuleAPI<Registry & { [Name]: T }>` — the type widens with each call. At runtime the same instance is returned (cast through the new type). |
+| Type-safe `get`       | `Injector<Registry>#get<K extends keyof Registry>(name: K)` returns `Registry[K]`, so calling `get('apiUrl')` infers the registered type. An overload `get<T>(name: string): T` provides the escape hatch. |
 
 ### Public API Exposure
 
@@ -119,7 +143,8 @@ interface Injector {
 
 | Risk                                                                     | Impact                                 | Mitigation                                                                                                                    |
 |--------------------------------------------------------------------------|----------------------------------------|-------------------------------------------------------------------------------------------------------------------------------|
-| Type inference for `injector.get('name')` without a generic type param   | Medium — callers may get `unknown`     | Accept this limitation. With `get<T>('name')`, callers opt into their known type. Advanced per-module typing is out of scope. |
+| Builder-pattern generic types may become complex or hit TS inference limits | Medium — may push against TS recursion/inference limits | Start with a simple intersection type `Registry & { [Name]: T }`. If inference degrades on long chains, fall back to the explicit-generic `get<T>(name)` escape hatch. The runtime behavior is identical either way. |
+| Merging registries across module dependencies (transitive types) | Medium — getting `MergeRegistries<[Mod1, Mod2, Mod3]>` right is non-trivial | Implement registry merging as a separate utility type; test with `expectTypeOf` or `satisfies` in the type-safety test suite. |
 | Circular module dependencies (module A depends on B, B depends on A)     | Medium — different from service cycles | Track loaded modules in a Set during graph walk. Shared dep is fine; circular module dep should throw.                        |
 | Global state (`registry` Map) makes tests order-dependent                | Medium — tests could leak state        | Expose a test-only `resetRegistry()` helper or use a factory function that creates isolated registries per test               |
 | `$inject` array length mismatch with function parameters                 | Low — runtime error                    | Validate in `invoke` and throw a clear error                                                                                  |

--- a/context/spec/007-dependency-injection-foundation/technical-considerations.md
+++ b/context/spec/007-dependency-injection-foundation/technical-considerations.md
@@ -10,11 +10,11 @@
 
 Build the DI system as a new module under `src/di/`. The module has three main pieces:
 
-1. **Module registry** — A singleton `Map<string, Module>` that stores all modules by name. Both `angular.module()` and `createModule()` read/write this same registry, so the APIs are interchangeable.
+1. **Module registry** — A singleton `Map<string, Module>` that stores all modules by name. `createModule()` and `getModule()` read/write this registry.
 2. **Module class** — Generic over a `Registry` type parameter that tracks all registered services as a mapped type `{ [K in registered name]: service type }`. Each `.value()` / `.constant()` / `.factory()` call returns `Module<Registry & { [newName]: newType }>` — a builder-pattern approach that accumulates type information across chained calls. Registration is *declarative* — nothing is instantiated until the injector is created.
 3. **Injector** — Created from a root module. Walks the dependency graph, collects all queued registrations, and provides `get`, `has`, `invoke`, `annotate` for resolving services. Uses lazy instantiation with a cache for singletons. The injector type is generic over the merged registry of all modules in the graph, so `injector.get('name')` infers the correct return type from string literal lookup.
 
-The `angular` namespace is a **thin wrapper** over `createModule` / `getModule` — `angular.module(name, requires)` literally calls `createModule(name, requires)` and `angular.module(name)` calls `getModule(name)`. There is ONE implementation; `angular` just provides a familiar surface for users migrating from classic AngularJS. The `angular` namespace is a named export that consumers import explicitly (`import { angular } from 'my-own-angularjs/di'`).
+All public APIs are exposed as ES module named exports (`createModule`, `getModule`, `createInjector`), consistent with the rest of the framework (`Scope.create`, `parse`, etc.). No global `angular` namespace — that is deferred to a dedicated AngularJS Compatibility Layer milestone in the roadmap.
 
 No architectural changes. The new module plugs into existing `src/di/` (currently empty) and extends `src/di/index.ts` as a barrel.
 
@@ -29,11 +29,10 @@ No architectural changes. The new module plugs into existing `src/di/` (currentl
 | File          | Responsibility                                                                                   |
 |---------------|--------------------------------------------------------------------------------------------------|
 | `di-types.ts` | Interfaces: `Annotated`, `ModuleAPI`, `Injector`, `Invokable`, `Recipe`                          |
-| `module.ts`   | `Module` class with `value`, `constant`, `factory` methods; module registry map                  |
+| `module.ts`   | `Module` class with `value`, `constant`, `factory` methods; module registry map; `createModule`, `getModule`, `resetRegistry` named exports |
 | `injector.ts` | `createInjector(modules)` factory; `Injector` with `get`, `has`, `invoke`, `annotate`            |
 | `annotate.ts` | `annotate(fn)` helper — extracts dependency names from `$inject` property or array-style         |
-| `angular.ts`  | `angular` namespace object with `module()` method, and named exports `createModule`, `getModule` |
-| `index.ts`    | Barrel: re-export `angular`, `createModule`, `getModule`, `createInjector`, types                |
+| `index.ts`    | Barrel: re-export `createModule`, `getModule`, `createInjector`, types                           |
 
 **Test file:** `src/di/__tests__/di.test.ts` — single file with nested `describe` blocks per feature area.
 
@@ -42,7 +41,7 @@ No architectural changes. The new module plugs into existing `src/di/` (currentl
 ```
 consumer code
      ↓
- angular.module('app', ['common'])   (or createModule/getModule)
+ createModule('app', ['common'])   (or getModule to retrieve)
      ↓
  Module registry (Map<string, Module>)
      ↓
@@ -116,7 +115,6 @@ type MergeRegistries<Modules extends readonly ModuleAPI<any>[]> = /* ... */;
 | Resolution path stack | `Array<string>` tracking in-progress resolutions for cycle detection                                                        |
 | `annotate`            | If `fn` is an array, pop last element as the actual fn and use rest as `$inject`. Else read `fn.$inject`. Throw if neither. |
 | Error messages        | `Unknown provider: <name>`, `Module not found: <name>`, `Circular dependency: A <- B <- A`                                  |
-| `angular` namespace   | **Thin wrapper.** `angular.module(name, requires)` is literally `(name, requires) => requires !== undefined ? createModule(name, requires) : getModule(name)`. One shared implementation. |
 | Builder-pattern types | `value` / `constant` / `factory` methods return `ModuleAPI<Registry & { [Name]: T }>` — the type widens with each call. At runtime the same instance is returned (cast through the new type). |
 | Type-safe `get`       | `Injector<Registry>#get<K extends keyof Registry>(name: K)` returns `Registry[K]`, so calling `get('apiUrl')` infers the registered type. An overload `get<T>(name: string): T` provides the escape hatch. |
 
@@ -124,8 +122,8 @@ type MergeRegistries<Modules extends readonly ModuleAPI<any>[]> = /* ... */;
 
 - **File:** `src/di/index.ts` — barrel export
 - **Existing `package.json` exports map** already has `/di` entry pointing to `dist/esm/di/index.mjs`
-- Consumers: `import { angular } from 'my-own-angularjs/di'` or `import { createModule, createInjector } from 'my-own-angularjs/di'`
-- Root `src/index.ts` will also re-export DI for `import { angular } from 'my-own-angularjs'`
+- Consumers: `import { createModule, getModule, createInjector } from 'my-own-angularjs/di'`
+- Root `src/index.ts` will also re-export DI for `import { createModule } from 'my-own-angularjs'`
 
 ---
 
@@ -157,7 +155,7 @@ type MergeRegistries<Modules extends readonly ModuleAPI<any>[]> = /* ... */;
 - **Location:** `src/di/__tests__/di.test.ts`
 - **Framework:** Vitest
 - **Organization:** One top-level `describe` per feature area:
-  - `describe('angular.module / createModule / getModule', ...)` — module creation, retrieval, shared registry
+  - `describe('createModule / getModule', ...)` — module creation, retrieval, registry isolation
   - `describe('Module dependency graph', ...)` — transitive deps, shared deps loaded once, missing module
   - `describe('Module.value / constant / factory', ...)` — registration of each recipe
   - `describe('Injector.get / has', ...)` — resolution, singleton caching, unknown provider

--- a/context/spec/007-dependency-injection-foundation/technical-considerations.md
+++ b/context/spec/007-dependency-injection-foundation/technical-considerations.md
@@ -1,0 +1,143 @@
+# Technical Specification: Dependency Injection — Foundation
+
+- **Functional Specification:** `context/spec/007-dependency-injection-foundation/functional-spec.md`
+- **Status:** Draft
+- **Author(s):** Mgrdich
+
+---
+
+## 1. High-Level Technical Approach
+
+Build the DI system as a new module under `src/di/`. The module has three main pieces:
+
+1. **Module registry** — A singleton `Map<string, Module>` that stores all modules by name. Both `angular.module()` and `createModule()` read/write this same registry, so the APIs are interchangeable.
+2. **Module class** — Holds the queued service registrations (`value`, `constant`, `factory`) as a list of invokables. Registration is *declarative* — nothing is instantiated until the injector is created.
+3. **Injector** — Created from a root module name. Walks the dependency graph, collects all queued registrations, and provides `get`, `has`, `invoke`, `annotate` for resolving services. Uses lazy instantiation with a cache for singletons.
+
+The `angular` namespace is a named export that provides the `module()` method. It is NOT a default export or a global — consumers import it explicitly (`import { angular } from 'my-own-angularjs/di'`).
+
+No architectural changes. The new module plugs into existing `src/di/` (currently empty) and extends `src/di/index.ts` as a barrel.
+
+---
+
+## 2. Proposed Solution & Implementation Plan
+
+### Component Breakdown
+
+**New files under `src/di/`:**
+
+| File          | Responsibility                                                                                   |
+|---------------|--------------------------------------------------------------------------------------------------|
+| `di-types.ts` | Interfaces: `Annotated`, `ModuleAPI`, `Injector`, `Invokable`, `Recipe`                          |
+| `module.ts`   | `Module` class with `value`, `constant`, `factory` methods; module registry map                  |
+| `injector.ts` | `createInjector(modules)` factory; `Injector` with `get`, `has`, `invoke`, `annotate`            |
+| `annotate.ts` | `annotate(fn)` helper — extracts dependency names from `$inject` property or array-style         |
+| `angular.ts`  | `angular` namespace object with `module()` method, and named exports `createModule`, `getModule` |
+| `index.ts`    | Barrel: re-export `angular`, `createModule`, `getModule`, `createInjector`, types                |
+
+**Test file:** `src/di/__tests__/di.test.ts` — single file with nested `describe` blocks per feature area.
+
+### Architecture & Data Flow
+
+```
+consumer code
+     ↓
+ angular.module('app', ['common'])   (or createModule/getModule)
+     ↓
+ Module registry (Map<string, Module>)
+     ↓
+ createInjector(['app'])
+     ↓
+ 1. Load modules: walk graph (app → common → ...), collect invokables
+ 2. Build providerCache: { value: <value>, factory: () => <instance>, ... }
+ 3. Return Injector { get, has, invoke, annotate }
+```
+
+### Key Type Definitions (signatures only, no implementation)
+
+```typescript
+// Dependency annotation
+type Annotated<Fn extends (...args: unknown[]) => unknown> = Fn & {
+  $inject?: readonly string[];
+};
+
+// Array-style invokable
+type InvokableArray = readonly [...string[], (...deps: unknown[]) => unknown];
+type Invokable = Annotated<(...args: unknown[]) => unknown> | InvokableArray;
+
+// Module API
+interface ModuleAPI {
+  readonly name: string;
+  readonly requires: readonly string[];
+  value<T>(name: string, value: T): ModuleAPI;
+  constant<T>(name: string, value: T): ModuleAPI;
+  factory(name: string, factory: Invokable): ModuleAPI;
+}
+
+// Injector API
+interface Injector {
+  get<T = unknown>(name: string): T;
+  has(name: string): boolean;
+  invoke<T = unknown>(fn: Invokable, self?: unknown, locals?: Record<string, unknown>): T;
+  annotate(fn: Invokable): readonly string[];
+}
+```
+
+### Key Implementation Details
+
+| Component             | Detail                                                                                                                      |
+|-----------------------|-----------------------------------------------------------------------------------------------------------------------------|
+| Module registry       | Module-scoped `const registry = new Map<string, Module>()` in `module.ts`                                                   |
+| Invokable queue       | `Module` stores registrations as `Array<['value' \| 'constant' \| 'factory', string, unknown]>`                             |
+| `createInjector`      | Walks dep graph via BFS, tracks loaded modules in a `Set` to handle shared deps once                                        |
+| Singleton cache       | `Map<string, unknown>` keyed by service name, populated lazily on first `get`                                               |
+| Resolution path stack | `Array<string>` tracking in-progress resolutions for cycle detection                                                        |
+| `annotate`            | If `fn` is an array, pop last element as the actual fn and use rest as `$inject`. Else read `fn.$inject`. Throw if neither. |
+| Error messages        | `Unknown provider: <name>`, `Module not found: <name>`, `Circular dependency: A <- B <- A`                                  |
+| `angular` namespace   | Object with `module(name, requires?)` method; same signature/behavior as `createModule` / `getModule`                       |
+
+### Public API Exposure
+
+- **File:** `src/di/index.ts` — barrel export
+- **Existing `package.json` exports map** already has `/di` entry pointing to `dist/esm/di/index.mjs`
+- Consumers: `import { angular } from 'my-own-angularjs/di'` or `import { createModule, createInjector } from 'my-own-angularjs/di'`
+- Root `src/index.ts` will also re-export DI for `import { angular } from 'my-own-angularjs'`
+
+---
+
+## 3. Impact and Risk Analysis
+
+### System Dependencies
+
+- **`src/di/` currently empty.** No existing code to break.
+- **`src/index.ts`** — needs one new re-export line
+- **Scope module** — not affected. Integration with Scope (registering `$rootScope` as a service) is out of scope for this spec.
+- **Parser module** — not affected.
+- **Build pipeline** — Rollup already handles `src/di/` via the exports map. Confirm the build produces `dist/esm/di/index.mjs`.
+
+### Potential Risks & Mitigations
+
+| Risk                                                                     | Impact                                 | Mitigation                                                                                                                    |
+|--------------------------------------------------------------------------|----------------------------------------|-------------------------------------------------------------------------------------------------------------------------------|
+| Type inference for `injector.get('name')` without a generic type param   | Medium — callers may get `unknown`     | Accept this limitation. With `get<T>('name')`, callers opt into their known type. Advanced per-module typing is out of scope. |
+| Circular module dependencies (module A depends on B, B depends on A)     | Medium — different from service cycles | Track loaded modules in a Set during graph walk. Shared dep is fine; circular module dep should throw.                        |
+| Global state (`registry` Map) makes tests order-dependent                | Medium — tests could leak state        | Expose a test-only `resetRegistry()` helper or use a factory function that creates isolated registries per test               |
+| `$inject` array length mismatch with function parameters                 | Low — runtime error                    | Validate in `invoke` and throw a clear error                                                                                  |
+| `Invokable` type is complex (union of array and function with `$inject`) | Low — affects type UX                  | Use type guards for runtime discrimination; provide helpful error messages when annotation is missing                         |
+
+---
+
+## 4. Testing Strategy
+
+- **Location:** `src/di/__tests__/di.test.ts`
+- **Framework:** Vitest
+- **Organization:** One top-level `describe` per feature area:
+  - `describe('angular.module / createModule / getModule', ...)` — module creation, retrieval, shared registry
+  - `describe('Module dependency graph', ...)` — transitive deps, shared deps loaded once, missing module
+  - `describe('Module.value / constant / factory', ...)` — registration of each recipe
+  - `describe('Injector.get / has', ...)` — resolution, singleton caching, unknown provider
+  - `describe('Injector.invoke / annotate', ...)` — both annotation styles, `self`, `locals`, unannotated function
+  - `describe('Circular dependency detection', ...)` — direct, indirect, 3-level cycles
+  - `describe('Type safety', ...)` — compile-time type assertions using `expectTypeOf` or `satisfies`
+- **Test isolation:** Each test creates its own isolated registry (or resets a shared one in `beforeEach`)
+- **Coverage target:** 90%+ on the new DI module

--- a/context/spec/007-dependency-injection-foundation/technical-considerations.md
+++ b/context/spec/007-dependency-injection-foundation/technical-considerations.md
@@ -1,7 +1,7 @@
 # Technical Specification: Dependency Injection — Foundation
 
 - **Functional Specification:** `context/spec/007-dependency-injection-foundation/functional-spec.md`
-- **Status:** Draft
+- **Status:** Completed
 - **Author(s):** Mgrdich
 
 ---

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -2,11 +2,32 @@ import typescript from '@rollup/plugin-typescript';
 import resolve from '@rollup/plugin-node-resolve';
 import dts from 'rollup-plugin-dts';
 
-const mainConfig = {
-  input: 'src/index.ts',
+// Per-entry bundle definitions. Each entry produces its own ESM + CJS bundle
+// plus a matching .d.ts file so the `package.json` `exports` map resolves.
+//
+// Note: each subpath bundle is built independently of the root, meaning any
+// shared internal modules (e.g. utilities pulled in by multiple entries) will
+// be inlined per bundle. That duplication is acceptable for a library where
+// the root import is the primary entry point and subpath imports are rare;
+// keeping each bundle self-contained is simpler to reason about than marking
+// cross-subpath internals external.
+//
+// `compiler` is included even though it currently just re-exports `{}`, so the
+// `./compiler` exports map entry resolves to a real file rather than failing
+// at runtime for any consumer who happens to import it.
+const entries = [
+  { name: 'index', input: 'src/index.ts' },
+  { name: 'core/index', input: 'src/core/index.ts' },
+  { name: 'di/index', input: 'src/di/index.ts' },
+  { name: 'parser/index', input: 'src/parser/index.ts' },
+  { name: 'compiler/index', input: 'src/compiler/index.ts' },
+];
+
+const bundleConfigs = entries.map((entry) => ({
+  input: entry.input,
   output: [
-    { file: 'dist/esm/index.mjs', format: 'es', sourcemap: true },
-    { file: 'dist/cjs/index.cjs', format: 'cjs', sourcemap: true },
+    { file: `dist/esm/${entry.name}.mjs`, format: 'es', sourcemap: true },
+    { file: `dist/cjs/${entry.name}.cjs`, format: 'cjs', sourcemap: true },
   ],
   external: ['tslib'],
   plugins: [
@@ -16,12 +37,12 @@ const mainConfig = {
       declarationDir: undefined,
     }),
   ],
-};
+}));
 
-const dtsConfig = {
-  input: 'src/index.ts',
-  output: [{ file: 'dist/types/index.d.ts', format: 'es' }],
+const dtsConfigs = entries.map((entry) => ({
+  input: entry.input,
+  output: [{ file: `dist/types/${entry.name}.d.ts`, format: 'es' }],
   plugins: [dts()],
-};
+}));
 
-export default [mainConfig, dtsConfig];
+export default [...bundleConfigs, ...dtsConfigs];

--- a/src/core/scope.ts
+++ b/src/core/scope.ts
@@ -1,7 +1,6 @@
 import {
   initWatchVal,
   type AsyncTask,
-  type DeregisterFn,
   type EventListener,
   type ListenerFn,
   type ScopeEvent,
@@ -68,7 +67,7 @@ export class Scope {
   }
 
   /** Create a typed Scope instance with compile-time property access. */
-  static create<T extends Record<string, unknown> = Record<string, unknown>>(options?: ScopeOptions): TypedScope<T> {
+  static create<T extends Record<string, unknown> = Record<string, unknown>>(options?: ScopeOptions) {
     if (options?.ttl !== undefined && options.ttl < 2) {
       throw new Error('TTL must be at least 2');
     }
@@ -85,7 +84,7 @@ export class Scope {
    * @param valueEq - Whether to use deep equality (not implemented in Slice 1)
    * @returns A function that deregisters the watcher when called
    */
-  $watch<W>(watchFn: WatchFn<W>, listenerFn?: ListenerFn<W>, valueEq?: boolean): DeregisterFn {
+  $watch<W>(watchFn: WatchFn<W>, listenerFn?: ListenerFn<W>, valueEq?: boolean) {
     const watcher: Watcher<W> = {
       watchFn,
       listenerFn: listenerFn ?? noop,
@@ -121,7 +120,7 @@ export class Scope {
    * @param parent - Optional parent scope for hierarchy (defaults to `this`)
    * @returns The new child scope
    */
-  $new(isolated?: boolean, parent?: Scope): Scope {
+  $new(isolated?: boolean, parent?: Scope) {
     const effectiveParent = parent ?? this;
     let child: Scope;
 
@@ -224,7 +223,7 @@ export class Scope {
    *
    * @throws When the digest does not stabilize within TTL iterations
    */
-  $digest(): void {
+  $digest() {
     let ttl = this.$root.$$ttl;
     let dirty: boolean;
 
@@ -285,7 +284,7 @@ export class Scope {
    * @param locals - Optional locals object passed as second argument
    * @returns The result of the expression, or undefined if no expr provided
    */
-  $eval<R>(expr?: (scope: Scope, locals?: unknown) => R, locals?: unknown): R | undefined {
+  $eval<R>(expr?: (scope: Scope, locals?: unknown) => R, locals?: unknown) {
     if (expr) {
       return expr(this, locals);
     }
@@ -298,7 +297,7 @@ export class Scope {
    * @param expr - Optional expression to evaluate before digesting
    * @returns The result of the expression
    */
-  $apply<R>(expr?: WatchFn<R>): R | undefined {
+  $apply<R>(expr?: WatchFn<R>) {
     this.$beginPhase('$apply');
     try {
       return this.$eval(expr);
@@ -313,7 +312,7 @@ export class Scope {
    * Broadcasts a `$destroy` event to this scope and all descendants before cleanup.
    * Clears watchers and listeners to prevent further digest participation.
    */
-  $destroy(): void {
+  $destroy() {
     if (this === this.$root) {
       return;
     }
@@ -336,7 +335,7 @@ export class Scope {
    * Queue an expression for deferred execution within the current or next digest.
    * If no digest is already in progress, schedules one via setTimeout.
    */
-  $evalAsync(expr: WatchFn<unknown>): void {
+  $evalAsync(expr: WatchFn<unknown>) {
     if (!this.$root.$$phase && this.$root.$$asyncQueue.length === 0) {
       setTimeout(() => {
         if (this.$root.$$asyncQueue.length > 0) {
@@ -351,7 +350,7 @@ export class Scope {
    * Coalesce multiple apply calls into a single setTimeout + $apply.
    * All queued expressions are flushed together in one digest cycle.
    */
-  $applyAsync(expr: WatchFn<unknown>): void {
+  $applyAsync(expr: WatchFn<unknown>) {
     this.$$applyAsyncQueue.push({ scope: this, expression: expr });
 
     if (this.$root.$$applyAsyncId === null) {
@@ -367,7 +366,7 @@ export class Scope {
    * Register a function to run once after the next digest cycle completes.
    * The function is not run inside the digest and will not trigger further digestion.
    */
-  $$postDigest(fn: () => void): void {
+  $$postDigest(fn: () => void) {
     this.$$postDigestQueue.push(fn);
   }
 
@@ -379,7 +378,7 @@ export class Scope {
    * @param listenerFn - Called with [newValues[], oldValues[], scope]
    * @returns A function that deregisters all grouped watchers
    */
-  $watchGroup(watchFns: WatchFn<unknown>[], listenerFn: ListenerFn<unknown[]>): DeregisterFn {
+  $watchGroup(watchFns: WatchFn<unknown>[], listenerFn: ListenerFn<unknown[]>) {
     const newValues: unknown[] = new Array(watchFns.length);
     const oldValues: unknown[] = new Array(watchFns.length);
     let changeReactionScheduled = false;
@@ -437,7 +436,7 @@ export class Scope {
    * @param listenerFn - Called with (newValue, oldValue, scope) when changes are detected
    * @returns A function that deregisters the watcher when called
    */
-  $watchCollection(watchFn: WatchFn<unknown>, listenerFn: ListenerFn<unknown>): DeregisterFn {
+  $watchCollection(watchFn: WatchFn<unknown>, listenerFn: ListenerFn<unknown>) {
     let changeCount = 0;
     let oldValue: unknown;
     let newValue: unknown;
@@ -560,7 +559,7 @@ export class Scope {
    * @param listener - Callback invoked when the event fires
    * @returns A function that deregisters the listener when called
    */
-  $on(eventName: string, listener: EventListener): DeregisterFn {
+  $on(eventName: string, listener: EventListener) {
     let listeners = this.$$listeners[eventName];
     if (!listeners) {
       listeners = [];
@@ -584,7 +583,7 @@ export class Scope {
    * @param args - Additional arguments passed to each listener after the event object
    * @returns The event object
    */
-  $emit(eventName: string, ...args: unknown[]): ScopeEvent {
+  $emit(eventName: string, ...args: unknown[]) {
     const state = { propagationStopped: false };
 
     const event: ScopeEvent = {
@@ -622,7 +621,7 @@ export class Scope {
    * @param args - Additional arguments passed to each listener after the event object
    * @returns The event object
    */
-  $broadcast(eventName: string, ...args: unknown[]): ScopeEvent {
+  $broadcast(eventName: string, ...args: unknown[]) {
     const event: ScopeEvent = {
       name: eventName,
       targetScope: this,
@@ -653,7 +652,7 @@ export class Scope {
    * @param event - The event object being propagated
    * @param additionalArgs - Extra arguments passed to each listener
    */
-  $$fireEventOnScope(event: ScopeEvent, additionalArgs: unknown[]): void {
+  $$fireEventOnScope(event: ScopeEvent, additionalArgs: unknown[]) {
     event.currentScope = this;
     const listeners = this.$$listeners[event.name];
     if (listeners) {

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -176,7 +176,7 @@ export function isArrayLike(value: unknown) {
  * When `destination` is provided, properties are copied into it (after
  * clearing existing contents) rather than creating a new container.
  */
-export function copy<T>(source: T, destination?: T): T {
+export function copy<T>(source: T, destination?: T) {
   if (destination !== undefined && source === destination) {
     throw new Error('Cannot copy! Source and destination are identical.');
   }
@@ -184,7 +184,7 @@ export function copy<T>(source: T, destination?: T): T {
   return copyRecursive(source, destination, visited);
 }
 
-function copyRecursive<T>(source: T, destination: T | undefined, visited: Set<T>): T {
+function copyRecursive<T>(source: T, destination: T | undefined, visited: Set<T>) {
   // Primitives: return as-is
   if (source === null || typeof source !== 'object') {
     if (destination !== undefined) {
@@ -292,10 +292,10 @@ export function forEach(
 }
 
 /** Empty function that does nothing. */
-export function noop(): void {}
+export function noop() {}
 
 /** Creates a bare object with no prototype. */
-export function createMap<T = unknown>(): Record<string, T> {
+export function createMap<T = unknown>() {
   return Object.create(null) as Record<string, T>;
 }
 
@@ -306,7 +306,7 @@ export function createMap<T = unknown>(): Record<string, T> {
  * - `range(start, end)` produces values from start (inclusive) to end (exclusive)
  * - `range(start, end, step)` produces values with the given step
  */
-export function range(startOrEnd: number, end?: number, step?: number): number[] {
+export function range(startOrEnd: number, end?: number, step?: number) {
   let actualStart: number;
   let actualEnd: number;
   let actualStep: number;

--- a/src/di/__tests__/di.test.ts
+++ b/src/di/__tests__/di.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, expectTypeOf, beforeEach, vi } from 'vitest';
 import { Module, createModule, getModule, resetRegistry } from '@di/module';
+import { createInjector } from '@di/injector';
 
 describe('createModule / getModule', () => {
   beforeEach(() => {
@@ -65,5 +66,663 @@ describe('createModule / getModule', () => {
       resetRegistry();
       expect(() => getModule('app')).toThrow('Module not found: app');
     });
+  });
+});
+
+describe('Module.value', () => {
+  beforeEach(() => {
+    resetRegistry();
+  });
+
+  it('pushes [value, name, value] to the invokeQueue', () => {
+    const mod = createModule('app', []);
+    mod.value('apiUrl', 'https://example.com');
+    expect(mod.invokeQueue[0]).toEqual(['value', 'apiUrl', 'https://example.com']);
+  });
+
+  it('returns the same module instance (for chaining)', () => {
+    const mod = createModule('app', []);
+    const result = mod.value('x', 1);
+    expect(result).toBe(mod);
+  });
+
+  it('supports chaining multiple value calls', () => {
+    const mod = createModule('app', []).value('a', 1).value('b', 2).value('c', 3);
+    expect(mod.invokeQueue.length).toBe(3);
+    expect(mod.invokeQueue[0]).toEqual(['value', 'a', 1]);
+    expect(mod.invokeQueue[1]).toEqual(['value', 'b', 2]);
+    expect(mod.invokeQueue[2]).toEqual(['value', 'c', 3]);
+  });
+
+  it('accepts a string value', () => {
+    const mod = createModule('app', []).value('s', 'hello');
+    expect(mod.invokeQueue[0]).toEqual(['value', 's', 'hello']);
+  });
+
+  it('accepts a number value', () => {
+    const mod = createModule('app', []).value('n', 42);
+    expect(mod.invokeQueue[0]).toEqual(['value', 'n', 42]);
+  });
+
+  it('accepts a boolean value', () => {
+    const mod = createModule('app', []).value('b', true);
+    expect(mod.invokeQueue[0]).toEqual(['value', 'b', true]);
+  });
+
+  it('accepts an object value (preserving reference identity)', () => {
+    const obj = { key: 'value' };
+    const mod = createModule('app', []).value('o', obj);
+    const entry = mod.invokeQueue[0];
+    expect(entry).toEqual(['value', 'o', obj]);
+    expect(entry).toBeDefined();
+    if (entry !== undefined) {
+      expect(entry[2]).toBe(obj);
+    }
+  });
+
+  it('accepts an array value (preserving reference identity)', () => {
+    const arr = [1, 2, 3];
+    const mod = createModule('app', []).value('a', arr);
+    const entry = mod.invokeQueue[0];
+    expect(entry).toEqual(['value', 'a', arr]);
+    expect(entry).toBeDefined();
+    if (entry !== undefined) {
+      expect(entry[2]).toBe(arr);
+    }
+  });
+
+  it('accepts a null value', () => {
+    const mod = createModule('app', []).value('nully', null);
+    expect(mod.invokeQueue[0]).toEqual(['value', 'nully', null]);
+  });
+
+  it('accepts an undefined value', () => {
+    const mod = createModule('app', []).value('undef', undefined);
+    expect(mod.invokeQueue[0]).toEqual(['value', 'undef', undefined]);
+  });
+
+  it('replaces an existing value when the same name is registered twice (later wins at injector drain)', () => {
+    const mod = createModule('app', []).value('x', 1).value('x', 2);
+    expect(mod.invokeQueue.length).toBe(2);
+    expect(mod.invokeQueue[0]).toEqual(['value', 'x', 1]);
+    expect(mod.invokeQueue[1]).toEqual(['value', 'x', 2]);
+
+    const injector = createInjector([mod]);
+    expect(injector.get('x')).toBe(2);
+  });
+});
+
+describe('Module.constant', () => {
+  beforeEach(() => {
+    resetRegistry();
+  });
+
+  it('pushes [constant, name, value] to the invokeQueue', () => {
+    const mod = createModule('app', []);
+    mod.constant('MAX', 100);
+    expect(mod.invokeQueue[0]).toEqual(['constant', 'MAX', 100]);
+  });
+
+  it('returns the same module instance (for chaining)', () => {
+    const mod = createModule('app', []);
+    const result = mod.constant('MAX', 100);
+    expect(result).toBe(mod);
+  });
+
+  it('supports chaining with value', () => {
+    const mod = createModule('app', []).value('a', 1).constant('MAX', 5).value('b', 2);
+    expect(mod.invokeQueue.length).toBe(3);
+    expect(mod.invokeQueue[0]).toEqual(['value', 'a', 1]);
+    expect(mod.invokeQueue[1]).toEqual(['constant', 'MAX', 5]);
+    expect(mod.invokeQueue[2]).toEqual(['value', 'b', 2]);
+  });
+});
+
+describe('Module.factory', () => {
+  beforeEach(() => {
+    resetRegistry();
+  });
+
+  it('pushes [factory, name, invokable] to invokeQueue (array-style)', () => {
+    const invokable = ['dep', (dep: unknown) => ({ dep })] as const;
+    const mod = createModule('app', []).factory('myService', invokable);
+    expect(mod.invokeQueue).toHaveLength(1);
+    const entry = mod.invokeQueue[0];
+    expect(entry?.[0]).toBe('factory');
+    expect(entry?.[1]).toBe('myService');
+    expect(entry?.[2]).toBe(invokable);
+  });
+
+  it('pushes [factory, name, invokable] to invokeQueue ($inject-annotated)', () => {
+    function makeService(dep: unknown) {
+      return { dep };
+    }
+    makeService.$inject = ['dep'];
+    const mod = createModule('app', []).factory('myService', makeService);
+    expect(mod.invokeQueue).toHaveLength(1);
+    const entry = mod.invokeQueue[0];
+    expect(entry?.[0]).toBe('factory');
+    expect(entry?.[1]).toBe('myService');
+    expect(entry?.[2]).toBe(makeService);
+  });
+
+  it('returns the same module instance (for chaining)', () => {
+    const mod = createModule('app', []);
+    const chained = mod.factory('myService', [() => ({})]);
+    expect(chained).toBe(mod);
+  });
+
+  it('supports chaining with value and constant', () => {
+    const mod = createModule('app', [])
+      .value('v', 1)
+      .constant('c', 2)
+      .factory('f', [() => 'result']);
+    expect(mod.invokeQueue).toHaveLength(3);
+    expect(mod.invokeQueue[0]?.[0]).toBe('value');
+    expect(mod.invokeQueue[1]?.[0]).toBe('constant');
+    expect(mod.invokeQueue[2]?.[0]).toBe('factory');
+  });
+});
+
+describe('createInjector (values and constants)', () => {
+  beforeEach(() => {
+    resetRegistry();
+  });
+
+  it('creates an injector from a single module', () => {
+    const mod = createModule('app', []).value('url', 'https://example.com');
+    const injector = createInjector([mod]);
+    expect(injector).toBeDefined();
+    expect(typeof injector.get).toBe('function');
+    expect(typeof injector.has).toBe('function');
+  });
+
+  it('injector.get(name) returns a registered value', () => {
+    const mod = createModule('app', []).value('url', 'https://example.com');
+    const injector = createInjector([mod]);
+    expect(injector.get('url')).toBe('https://example.com');
+  });
+
+  it('injector.get(name) returns a registered constant', () => {
+    const mod = createModule('app', []).constant('MAX', 100);
+    const injector = createInjector([mod]);
+    expect(injector.get('MAX')).toBe(100);
+  });
+
+  it('injector.get(name) returns the same reference on multiple calls (singleton caching)', () => {
+    const obj = { foo: 'bar' };
+    const mod = createModule('app', []).value('obj', obj);
+    const injector = createInjector([mod]);
+    const first = injector.get('obj');
+    const second = injector.get('obj');
+    expect(first).toBe(second);
+    expect(first).toBe(obj);
+  });
+
+  it('injector.get(unknown) throws "Unknown provider: <name>"', () => {
+    const injector = createInjector([createModule('app', [])]);
+    expect(() => injector.get<unknown>('foo')).toThrow('Unknown provider: foo');
+  });
+
+  it('injector.has(name) returns true for registered values', () => {
+    const mod = createModule('app', []).value('url', 'https://example.com');
+    const injector = createInjector([mod]);
+    expect(injector.has('url')).toBe(true);
+  });
+
+  it('injector.has(name) returns false for unregistered services', () => {
+    const injector = createInjector([createModule('app', [])]);
+    expect(injector.has('nonexistent')).toBe(false);
+  });
+
+  it('injector.has(name) returns true for both values and constants', () => {
+    const mod = createModule('app', []).value('url', 'https://example.com').constant('MAX', 100);
+    const injector = createInjector([mod]);
+    expect(injector.has('url')).toBe(true);
+    expect(injector.has('MAX')).toBe(true);
+  });
+});
+
+describe('createInjector (multiple modules)', () => {
+  beforeEach(() => {
+    resetRegistry();
+  });
+
+  it('merges values and constants from multiple modules', () => {
+    const a = createModule('a', []).value('aValue', 1);
+    const b = createModule('b', []).value('bValue', 2);
+    const injector = createInjector([a, b]);
+    expect(injector.get('aValue')).toBe(1);
+    expect(injector.get('bValue')).toBe(2);
+  });
+
+  it('later modules override earlier modules when the same name is registered', () => {
+    const a = createModule('a', []).value('shared', 'from a');
+    const b = createModule('b', []).value('shared', 'from b');
+    const injector = createInjector([a, b]);
+    expect(injector.get('shared')).toBe('from b');
+  });
+});
+
+describe('createInjector (module dependency graph)', () => {
+  beforeEach(() => {
+    resetRegistry();
+  });
+
+  it('loads a required module declared in `requires`', () => {
+    createModule('common', []).value('logger', 'the-logger');
+    const app = createModule('app', ['common']).value('apiUrl', 'https://...');
+    const injector = createInjector([app]);
+    // `injector.get('logger')` uses the escape-hatch runtime path because
+    // `MergeRegistries<[typeof app]>` only sees `app`'s own Registry, not
+    // `common`'s. This test verifies runtime behavior only.
+    expect(injector.get('logger')).toBe('the-logger');
+    expect(injector.get('apiUrl')).toBe('https://...');
+  });
+
+  it('loads a chain of transitive dependencies (app -> b -> c)', () => {
+    createModule('c', []).value('cValue', 'from c');
+    createModule('b', ['c']).value('bValue', 'from b');
+    const app = createModule('app', ['b']).value('appValue', 'from app');
+    const injector = createInjector([app]);
+    expect(injector.get('cValue')).toBe('from c');
+    expect(injector.get('bValue')).toBe('from b');
+    expect(injector.get('appValue')).toBe('from app');
+  });
+
+  it('loads a shared dependency only once (diamond)', () => {
+    // Reference-identity check on the shared value proves it wasn't
+    // re-drained as a second entry under a different binding.
+    const sharedMarker = { marker: 'shared' };
+    createModule('common', []).value('shared', sharedMarker);
+    createModule('a', ['common']).value('aValue', 1);
+    createModule('b', ['common']).value('bValue', 2);
+    const app = createModule('app', ['a', 'b']).value('appValue', 3);
+    const injector = createInjector([app]);
+    expect(injector.get('shared')).toBe(sharedMarker);
+    expect(injector.get('aValue')).toBe(1);
+    expect(injector.get('bValue')).toBe(2);
+    expect(injector.get('appValue')).toBe(3);
+  });
+
+  it('drains dependencies before their dependents (post-order)', () => {
+    createModule('common', []).value('config', 'common-config');
+    const app = createModule('app', ['common']).value('config', 'app-config');
+    const injector = createInjector([app]);
+    // app.value runs AFTER common.value, so app wins.
+    expect(injector.get('config')).toBe('app-config');
+  });
+
+  it('throws when a required module is not registered', () => {
+    const app = createModule('app', ['nonexistent']).value('apiUrl', 'https://...');
+    expect(() => createInjector([app])).toThrow('Module not found: nonexistent');
+  });
+
+  it('throws when a transitive required module is not registered', () => {
+    createModule('b', ['nonexistent']).value('bValue', 'from b');
+    const app = createModule('app', ['b']);
+    expect(() => createInjector([app])).toThrow('Module not found: nonexistent');
+  });
+
+  it('handles circular module dependencies without infinite loop', () => {
+    // Two-phase setup: `createModule` only records the `requires` list; the
+    // other module only needs to exist in the registry at injector-load time.
+    createModule('a', ['b']).value('aValue', 'from a');
+    createModule('b', ['a']).value('bValue', 'from b');
+    const a = getModule('a');
+    const injector = createInjector([a]);
+    expect(injector.get('aValue')).toBe('from a');
+    expect(injector.get('bValue')).toBe('from b');
+  });
+
+  it('loads multiple root modules with overlapping dep graphs', () => {
+    createModule('common', []).value('common', 'shared');
+    const featA = createModule('featA', ['common']).value('a', 1);
+    const featB = createModule('featB', ['common']).value('b', 2);
+    const injector = createInjector([featA, featB]);
+    expect(injector.get('common')).toBe('shared');
+    expect(injector.get('a')).toBe(1);
+    expect(injector.get('b')).toBe(2);
+  });
+});
+
+describe('createInjector (factories)', () => {
+  beforeEach(() => {
+    resetRegistry();
+  });
+
+  it('invokes a factory with no dependencies and returns its result', () => {
+    const mod = createModule('app', []).factory('greeting', [() => 'hello']);
+    const injector = createInjector([mod]);
+    expect(injector.get('greeting')).toBe('hello');
+  });
+
+  it('invokes a $inject-annotated factory function', () => {
+    function makeGreeting() {
+      return 'hello';
+    }
+    makeGreeting.$inject = [] as string[];
+    const mod = createModule('app', []).factory('greeting', makeGreeting);
+    const injector = createInjector([mod]);
+    expect(injector.get('greeting')).toBe('hello');
+  });
+
+  it('invokes a factory with a value dependency (array-style)', () => {
+    const mod = createModule('app', [])
+      .value('name', 'World')
+      .factory('greeting', ['name', (name: string) => `hello ${name}`]);
+    const injector = createInjector([mod]);
+    expect(injector.get('greeting')).toBe('hello World');
+  });
+
+  it('invokes a factory with a value dependency ($inject-annotated)', () => {
+    function makeGreeting(name: string) {
+      return `hello ${name}`;
+    }
+    makeGreeting.$inject = ['name'];
+    const mod = createModule('app', []).value('name', 'World').factory('greeting', makeGreeting);
+    const injector = createInjector([mod]);
+    expect(injector.get('greeting')).toBe('hello World');
+  });
+
+  it('invokes a factory with multiple dependencies', () => {
+    const mod = createModule('app', [])
+      .value('first', 'Jane')
+      .value('last', 'Doe')
+      .factory('fullName', ['first', 'last', (f: string, l: string) => `${f} ${l}`]);
+    const injector = createInjector([mod]);
+    expect(injector.get('fullName')).toBe('Jane Doe');
+  });
+
+  it('invokes a factory that depends on another factory', () => {
+    const mod = createModule('app', [])
+      .factory('dep', [() => 'dep-value'])
+      .factory('consumer', ['dep', (d: string) => `consumer(${d})`]);
+    const injector = createInjector([mod]);
+    expect(injector.get('consumer')).toBe('consumer(dep-value)');
+  });
+
+  it('caches factory result (singleton) — invokes only once', () => {
+    const factoryFn = vi.fn(() => ({ id: Math.random() }));
+    const mod = createModule('app', []).factory('svc', [factoryFn]);
+    const injector = createInjector([mod]);
+    const first = injector.get('svc');
+    const second = injector.get('svc');
+    expect(first).toBe(second);
+    expect(factoryFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not invoke factory at load time (lazy)', () => {
+    const factoryFn = vi.fn(() => 'value');
+    const mod = createModule('app', []).factory('svc', [factoryFn]);
+    createInjector([mod]);
+    expect(factoryFn).not.toHaveBeenCalled();
+  });
+
+  it('invokes factory only on first `get` call', () => {
+    const factoryFn = vi.fn(() => 'value');
+    const mod = createModule('app', []).factory('svc', [factoryFn]);
+    const injector = createInjector([mod]);
+    expect(factoryFn).not.toHaveBeenCalled();
+    injector.get('svc');
+    expect(factoryFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('`injector.has` returns true for a registered factory (before and after invocation)', () => {
+    const mod = createModule('app', []).factory('svc', [() => 'value']);
+    const injector = createInjector([mod]);
+    expect(injector.has('svc')).toBe(true);
+    injector.get('svc');
+    expect(injector.has('svc')).toBe(true);
+  });
+
+  it('throws "Unknown provider" when get is called for an unregistered factory', () => {
+    const injector = createInjector([]);
+    expect(() => injector.get('nonexistent' as string)).toThrow('Unknown provider: nonexistent');
+  });
+
+  it('factory from a dep module is resolved when the dep module is loaded via requires', () => {
+    createModule('common', []).factory('logger', [() => ({ log: () => undefined })]);
+    const app = createModule('app', ['common']).value('apiUrl', 'https://example.com');
+    const injector = createInjector([app]);
+    const logger = injector.get<{ log: () => void }>('logger');
+    expect(logger).toBeDefined();
+    expect(logger.log).toBeInstanceOf(Function);
+  });
+});
+
+describe('type safety', () => {
+  beforeEach(() => {
+    resetRegistry();
+  });
+
+  it('module.value infers the value type (string)', () => {
+    const m = createModule('app', []).value('apiUrl', 'https://example.com');
+    const injector = createInjector([m]);
+    expectTypeOf(injector.get('apiUrl')).toEqualTypeOf<string>();
+  });
+
+  it('module.constant infers the value type (number)', () => {
+    const m = createModule('app', []).constant('MAX', 5);
+    const injector = createInjector([m]);
+    expectTypeOf(injector.get('MAX')).toEqualTypeOf<number>();
+  });
+
+  it('chained value and constant widen the registry correctly', () => {
+    const m = createModule('app', [])
+      .value('apiUrl', 'https://example.com')
+      .value('timeout', 30)
+      .constant('MAX', 5);
+    const injector = createInjector([m]);
+    expectTypeOf(injector.get('apiUrl')).toEqualTypeOf<string>();
+    expectTypeOf(injector.get('timeout')).toEqualTypeOf<number>();
+    expectTypeOf(injector.get('MAX')).toEqualTypeOf<number>();
+  });
+
+  it('object values preserve their shape', () => {
+    const m = createModule('app', []).value('config', { timeout: 30, retries: 3 });
+    const injector = createInjector([m]);
+    expectTypeOf(injector.get('config')).toEqualTypeOf<{ timeout: number; retries: number }>();
+  });
+
+  it('function values preserve their signature', () => {
+    const m = createModule('app', []).value('logger', (msg: string) => {
+      void msg;
+    });
+    const injector = createInjector([m]);
+    expectTypeOf(injector.get('logger')).toEqualTypeOf<(msg: string) => void>();
+  });
+
+  it('multiple modules merge registries correctly', () => {
+    const a = createModule('a', []).value('aValue', 'from a');
+    const b = createModule('b', []).value('bValue', 42);
+    const injector = createInjector([a, b]);
+    expectTypeOf(injector.get('aValue')).toEqualTypeOf<string>();
+    expectTypeOf(injector.get('bValue')).toEqualTypeOf<number>();
+  });
+
+  it('escape-hatch generic get<T> works for dynamic-name lookups', () => {
+    const m = createModule('app', []).value('apiUrl', 'https://example.com');
+    const injector = createInjector([m]);
+    // Register a dynamic value under an unknown name via the typed path first,
+    // then retrieve it through the escape-hatch overload with an explicit
+    // generic `T`. The escape-hatch `get<T>(name: string): T` overload is
+    // selected when the caller supplies an explicit generic and a plain
+    // `string` (not a literal keyof Registry).
+    type CustomShape = { custom: boolean };
+    const dynamicName: string = 'apiUrl';
+    const customValue = injector.get<CustomShape>(dynamicName);
+    expectTypeOf(customValue).toEqualTypeOf<CustomShape>();
+  });
+
+  it('createModule preserves the name literal', () => {
+    const m = createModule('app', []);
+    expectTypeOf(m.name).toEqualTypeOf<'app'>();
+  });
+
+  it('createModule preserves the requires tuple literal', () => {
+    const m = createModule('app', ['common', 'utils']);
+    expectTypeOf(m.requires).toEqualTypeOf<readonly ['common', 'utils']>();
+  });
+
+  it('empty requires defaults to readonly []', () => {
+    const m = createModule('app', []);
+    expectTypeOf(m.requires).toEqualTypeOf<readonly []>();
+  });
+
+  it('typed get with a registered key compiles and returns the correct type', () => {
+    const m = createModule('app', []).value('apiUrl', 'https://example.com');
+    const injector = createInjector([m]);
+    // This line must compile without error -- 'apiUrl' is a statically-known
+    // key of the merged registry and picks the typed `get` overload.
+    const url = injector.get('apiUrl');
+    expectTypeOf(url).toEqualTypeOf<string>();
+  });
+
+  it('typed get with an unregistered key is rejected by the typed overload', () => {
+    const m = createModule('app', []).value('apiUrl', 'https://example.com');
+    const injector = createInjector([m]);
+    // Isolate the typed overload from the `Injector` interface so that
+    // overload resolution cannot fall through to the escape-hatch
+    // `get<T>(name: string): T`. Once extracted as a standalone function
+    // type, only the `K extends keyof Registry` signature is visible, so
+    // passing an unregistered literal key is a compile error.
+    type Registry = { apiUrl: string };
+    type TypedGet = <K extends keyof Registry>(name: K) => Registry[K];
+    const typedGet: TypedGet = injector.get.bind(injector);
+    // Positive check: a registered key compiles and returns the correct type.
+    expectTypeOf(typedGet('apiUrl')).toEqualTypeOf<string>();
+    // Negative check: an unregistered literal key is a compile error on the
+    // typed overload. The runtime call throws "Unknown provider", which we
+    // catch so the test still completes — only the compile-time
+    // `@ts-expect-error` assertion matters here.
+    try {
+      // @ts-expect-error -- 'nonexistent' is not in the typed registry
+      typedGet('nonexistent');
+    } catch {
+      /* expected: runtime throws on unregistered name */
+    }
+  });
+
+  it('services from a dep module are typed when all modules are passed to createInjector', () => {
+    const common = createModule('common', []).value('logger', {
+      log: (m: string): undefined => {
+        void m;
+        return undefined;
+      },
+    });
+    const app = createModule('app', ['common']).value('apiUrl', 'https://example.com');
+    // Pass BOTH modules so MergeRegistries can union their Registry type params
+    const injector = createInjector([common, app]);
+    expectTypeOf(injector.get('logger')).toEqualTypeOf<{ log: (m: string) => undefined }>();
+    expectTypeOf(injector.get('apiUrl')).toEqualTypeOf<string>();
+  });
+
+  it('services from multiple dep modules all merge into the injector type', () => {
+    const a = createModule('a', []).value('aValue', 'from a');
+    const b = createModule('b', []).value('bValue', 42);
+    const c = createModule('c', []).value('cValue', true);
+    const app = createModule('app', ['a', 'b', 'c']).value('appValue', [1, 2, 3]);
+    const injector = createInjector([a, b, c, app]);
+    expectTypeOf(injector.get('aValue')).toEqualTypeOf<string>();
+    expectTypeOf(injector.get('bValue')).toEqualTypeOf<number>();
+    expectTypeOf(injector.get('cValue')).toEqualTypeOf<boolean>();
+    expectTypeOf(injector.get('appValue')).toEqualTypeOf<number[]>();
+  });
+
+  it('services only available via runtime dep walking use the escape-hatch type', () => {
+    createModule('common', []).value('runtimeOnly', 'visible at runtime');
+    const app = createModule('app', ['common']).value('apiUrl', 'https://example.com');
+    // Only `app` is passed to createInjector
+    const injector = createInjector([app]);
+    // Typed path: works for app's own services
+    expectTypeOf(injector.get('apiUrl')).toEqualTypeOf<string>();
+    // Escape-hatch path: runtimeOnly is loaded at runtime but NOT in the typed
+    // registry of `[app]`. The typed `get<K extends keyof Registry>` overload
+    // doesn't match because 'runtimeOnly' isn't a statically-known key, so
+    // lookups fall through to the escape-hatch `get<T>(name: string): T`. We
+    // ask for a concrete branded shape that clearly is not assignable to
+    // `keyof Registry` so overload resolution lands on the escape hatch.
+    type RuntimeOnly = { readonly __runtimeOnly: string };
+    const dynamicName: string = 'runtimeOnly';
+    const runtimeValue = injector.get<RuntimeOnly>(dynamicName);
+    expectTypeOf(runtimeValue).toEqualTypeOf<RuntimeOnly>();
+    // Runtime still works because the module was loaded via requires; the
+    // value comes back as the raw string we registered, which we immediately
+    // narrow through `unknown` for the runtime assertion.
+    expect(runtimeValue as unknown).toBe('visible at runtime');
+  });
+
+  it('MergeRegistries handles an empty module list', () => {
+    const injector = createInjector([]);
+    // No values registered; get should still be callable on the escape-hatch path
+    expect(() => injector.get('anything' as string)).toThrow('Unknown provider: anything');
+  });
+
+  it('merges disjoint modules into a single typed registry', () => {
+    const core = createModule('core', []).value('version', '1.0');
+    const feat = createModule('feat', []).constant('FEATURE_FLAG', 'on' as const);
+    const injector = createInjector([core, feat]);
+    expectTypeOf(injector.get('version')).toEqualTypeOf<string>();
+    expectTypeOf(injector.get('FEATURE_FLAG')).toEqualTypeOf<'on'>();
+  });
+
+  it('factory with explicit generic T infers return type on injector.get', () => {
+    type Logger = { log: (m: string) => void };
+    const mod = createModule('app', []).factory<'logger', Logger>('logger', [
+      () => ({
+        log: (m: string) => {
+          void m;
+        },
+      }),
+    ]);
+    const injector = createInjector([mod]);
+    expectTypeOf(injector.get('logger')).toEqualTypeOf<Logger>();
+  });
+
+  it('factory infers return type from invokable when no explicit generic is provided', () => {
+    const mod = createModule('app', []).factory('svc', [() => ({ foo: 'bar' })]);
+    const injector = createInjector([mod]);
+    expectTypeOf(injector.get('svc')).toEqualTypeOf<{ foo: string }>();
+  });
+
+  it('factory merges into registry alongside value and constant', () => {
+    type Greeter = { hello: () => string };
+    const mod = createModule('app', [])
+      .value('name', 'World')
+      .constant('PREFIX', '>>')
+      .factory<'greeter', Greeter>('greeter', [
+        'name',
+        (name: string): Greeter => ({ hello: () => `hi ${name}` }),
+      ]);
+    const injector = createInjector([mod]);
+    expectTypeOf(injector.get('name')).toEqualTypeOf<string>();
+    expectTypeOf(injector.get('PREFIX')).toEqualTypeOf<string>();
+    expectTypeOf(injector.get('greeter')).toEqualTypeOf<Greeter>();
+  });
+
+  it('factories from multiple modules merge into the injector type', () => {
+    type Clock = { now: () => number };
+    type Random = { next: () => number };
+    const core = createModule('core', []).factory<'clock', Clock>('clock', [
+      () => ({ now: () => Date.now() }),
+    ]);
+    const rand = createModule('rand', []).factory<'random', Random>('random', [
+      () => ({ next: () => Math.random() }),
+    ]);
+    const injector = createInjector([core, rand]);
+    expectTypeOf(injector.get('clock')).toEqualTypeOf<Clock>();
+    expectTypeOf(injector.get('random')).toEqualTypeOf<Random>();
+  });
+
+  it('$inject-annotated factory with explicit generic T infers return type', () => {
+    type Counter = { value: number };
+    function makeCounter(): Counter {
+      return { value: 0 };
+    }
+    makeCounter.$inject = [] as string[];
+    const mod = createModule('app', []).factory<'counter', Counter>('counter', makeCounter);
+    const injector = createInjector([mod]);
+    expectTypeOf(injector.get('counter')).toEqualTypeOf<Counter>();
   });
 });

--- a/src/di/__tests__/di.test.ts
+++ b/src/di/__tests__/di.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { Module, createModule, getModule, resetRegistry } from '@di/module';
+
+describe('createModule / getModule', () => {
+  beforeEach(() => {
+    resetRegistry();
+  });
+
+  describe('creation', () => {
+    it('creates a module with no dependencies', () => {
+      const mod = createModule('app', []);
+      expect(mod).toBeInstanceOf(Module);
+      expect(mod.name).toBe('app');
+      expect(mod.requires.length).toBe(0);
+    });
+
+    it('creates a module with dependencies', () => {
+      const mod = createModule('app', ['common', 'utils']);
+      expect(mod.requires).toEqual(['common', 'utils']);
+    });
+
+    it('defaults requires to an empty array when not provided', () => {
+      const mod = createModule('app');
+      expect(mod.requires.length).toBe(0);
+    });
+
+    it('the returned module has an empty invokeQueue', () => {
+      const mod = createModule('app', []);
+      expect(mod.invokeQueue.length).toBe(0);
+    });
+  });
+
+  describe('retrieval', () => {
+    it('retrieves a previously-created module', () => {
+      const created = createModule('app', []);
+
+      expect(getModule('app')).toBe(created);
+    });
+
+    it('returns the same reference on multiple retrievals', () => {
+      createModule('app', []);
+      expect(getModule('app')).toBe(getModule('app'));
+    });
+
+    it('throws on retrieving a non-existent module', () => {
+      expect(() => getModule('nonexistent')).toThrow('Module not found: nonexistent');
+    });
+
+    it('throws with the correct module name in the error message', () => {
+      expect(() => getModule('foo')).toThrow('Module not found: foo');
+    });
+  });
+
+  describe('replacement and isolation', () => {
+    it('creating a module with the same name replaces the previous one', () => {
+      createModule('app', ['a']);
+      createModule('app', ['b']);
+      expect(getModule('app').requires).toEqual(['b']);
+    });
+
+    it('resetRegistry() clears all modules', () => {
+      createModule('app', []);
+      createModule('common', []);
+      createModule('utils', []);
+      resetRegistry();
+      expect(() => getModule('app')).toThrow('Module not found: app');
+    });
+  });
+});

--- a/src/di/__tests__/di.test.ts
+++ b/src/di/__tests__/di.test.ts
@@ -2,727 +2,763 @@ import { describe, it, expect, expectTypeOf, beforeEach, vi } from 'vitest';
 import { Module, createModule, getModule, resetRegistry } from '@di/module';
 import { createInjector } from '@di/injector';
 
-describe('createModule / getModule', () => {
-  beforeEach(() => {
-    resetRegistry();
-  });
-
-  describe('creation', () => {
-    it('creates a module with no dependencies', () => {
-      const mod = createModule('app', []);
-      expect(mod).toBeInstanceOf(Module);
-      expect(mod.name).toBe('app');
-      expect(mod.requires.length).toBe(0);
-    });
-
-    it('creates a module with dependencies', () => {
-      const mod = createModule('app', ['common', 'utils']);
-      expect(mod.requires).toEqual(['common', 'utils']);
-    });
-
-    it('defaults requires to an empty array when not provided', () => {
-      const mod = createModule('app');
-      expect(mod.requires.length).toBe(0);
-    });
-
-    it('the returned module has an empty invokeQueue', () => {
-      const mod = createModule('app', []);
-      expect(mod.invokeQueue.length).toBe(0);
-    });
-  });
-
-  describe('retrieval', () => {
-    it('retrieves a previously-created module', () => {
-      const created = createModule('app', []);
-
-      expect(getModule('app')).toBe(created);
-    });
-
-    it('returns the same reference on multiple retrievals', () => {
-      createModule('app', []);
-      expect(getModule('app')).toBe(getModule('app'));
-    });
-
-    it('throws on retrieving a non-existent module', () => {
-      expect(() => getModule('nonexistent')).toThrow('Module not found: nonexistent');
-    });
-
-    it('throws with the correct module name in the error message', () => {
-      expect(() => getModule('foo')).toThrow('Module not found: foo');
-    });
-  });
-
-  describe('replacement and isolation', () => {
-    it('creating a module with the same name replaces the previous one', () => {
-      createModule('app', ['a']);
-      createModule('app', ['b']);
-      expect(getModule('app').requires).toEqual(['b']);
-    });
-
-    it('resetRegistry() clears all modules', () => {
-      createModule('app', []);
-      createModule('common', []);
-      createModule('utils', []);
+describe('dependency injection', () => {
+  describe('createModule / getModule', () => {
+    beforeEach(() => {
       resetRegistry();
-      expect(() => getModule('app')).toThrow('Module not found: app');
+    });
+
+    describe('creation', () => {
+      it('creates a module with no dependencies', () => {
+        const mod = createModule('app', []);
+        expect(mod).toBeInstanceOf(Module);
+        expect(mod.name).toBe('app');
+        expect(mod.requires.length).toBe(0);
+      });
+
+      it('creates a module with dependencies', () => {
+        const mod = createModule('app', ['common', 'utils']);
+        expect(mod.requires).toEqual(['common', 'utils']);
+      });
+
+      it('defaults requires to an empty array when not provided', () => {
+        const mod = createModule('app');
+        expect(mod.requires.length).toBe(0);
+      });
+
+      it('the returned module has an empty invokeQueue', () => {
+        const mod = createModule('app', []);
+        expect(mod.invokeQueue.length).toBe(0);
+      });
+    });
+
+    describe('retrieval', () => {
+      it('retrieves a previously-created module', () => {
+        const created = createModule('app', []);
+
+        expect(getModule('app')).toBe(created);
+      });
+
+      it('returns the same reference on multiple retrievals', () => {
+        createModule('app', []);
+        expect(getModule('app')).toBe(getModule('app'));
+      });
+
+      it('throws on retrieving a non-existent module', () => {
+        expect(() => getModule('nonexistent')).toThrow('Module not found: nonexistent');
+      });
+
+      it('throws with the correct module name in the error message', () => {
+        expect(() => getModule('foo')).toThrow('Module not found: foo');
+      });
+    });
+
+    describe('replacement and isolation', () => {
+      it('creating a module with the same name replaces the previous one', () => {
+        createModule('app', ['a']);
+        createModule('app', ['b']);
+        expect(getModule('app').requires).toEqual(['b']);
+      });
+
+      it('resetRegistry() clears all modules', () => {
+        createModule('app', []);
+        createModule('common', []);
+        createModule('utils', []);
+        resetRegistry();
+        expect(() => getModule('app')).toThrow('Module not found: app');
+      });
     });
   });
-});
 
-describe('Module.value', () => {
-  beforeEach(() => {
-    resetRegistry();
-  });
-
-  it('pushes [value, name, value] to the invokeQueue', () => {
-    const mod = createModule('app', []);
-    mod.value('apiUrl', 'https://example.com');
-    expect(mod.invokeQueue[0]).toEqual(['value', 'apiUrl', 'https://example.com']);
-  });
-
-  it('returns the same module instance (for chaining)', () => {
-    const mod = createModule('app', []);
-    const result = mod.value('x', 1);
-    expect(result).toBe(mod);
-  });
-
-  it('supports chaining multiple value calls', () => {
-    const mod = createModule('app', []).value('a', 1).value('b', 2).value('c', 3);
-    expect(mod.invokeQueue.length).toBe(3);
-    expect(mod.invokeQueue[0]).toEqual(['value', 'a', 1]);
-    expect(mod.invokeQueue[1]).toEqual(['value', 'b', 2]);
-    expect(mod.invokeQueue[2]).toEqual(['value', 'c', 3]);
-  });
-
-  it('accepts a string value', () => {
-    const mod = createModule('app', []).value('s', 'hello');
-    expect(mod.invokeQueue[0]).toEqual(['value', 's', 'hello']);
-  });
-
-  it('accepts a number value', () => {
-    const mod = createModule('app', []).value('n', 42);
-    expect(mod.invokeQueue[0]).toEqual(['value', 'n', 42]);
-  });
-
-  it('accepts a boolean value', () => {
-    const mod = createModule('app', []).value('b', true);
-    expect(mod.invokeQueue[0]).toEqual(['value', 'b', true]);
-  });
-
-  it('accepts an object value (preserving reference identity)', () => {
-    const obj = { key: 'value' };
-    const mod = createModule('app', []).value('o', obj);
-    const entry = mod.invokeQueue[0];
-    expect(entry).toEqual(['value', 'o', obj]);
-    expect(entry).toBeDefined();
-    if (entry !== undefined) {
-      expect(entry[2]).toBe(obj);
-    }
-  });
-
-  it('accepts an array value (preserving reference identity)', () => {
-    const arr = [1, 2, 3];
-    const mod = createModule('app', []).value('a', arr);
-    const entry = mod.invokeQueue[0];
-    expect(entry).toEqual(['value', 'a', arr]);
-    expect(entry).toBeDefined();
-    if (entry !== undefined) {
-      expect(entry[2]).toBe(arr);
-    }
-  });
-
-  it('accepts a null value', () => {
-    const mod = createModule('app', []).value('nully', null);
-    expect(mod.invokeQueue[0]).toEqual(['value', 'nully', null]);
-  });
-
-  it('accepts an undefined value', () => {
-    const mod = createModule('app', []).value('undef', undefined);
-    expect(mod.invokeQueue[0]).toEqual(['value', 'undef', undefined]);
-  });
-
-  it('replaces an existing value when the same name is registered twice (later wins at injector drain)', () => {
-    const mod = createModule('app', []).value('x', 1).value('x', 2);
-    expect(mod.invokeQueue.length).toBe(2);
-    expect(mod.invokeQueue[0]).toEqual(['value', 'x', 1]);
-    expect(mod.invokeQueue[1]).toEqual(['value', 'x', 2]);
-
-    const injector = createInjector([mod]);
-    expect(injector.get('x')).toBe(2);
-  });
-});
-
-describe('Module.constant', () => {
-  beforeEach(() => {
-    resetRegistry();
-  });
-
-  it('pushes [constant, name, value] to the invokeQueue', () => {
-    const mod = createModule('app', []);
-    mod.constant('MAX', 100);
-    expect(mod.invokeQueue[0]).toEqual(['constant', 'MAX', 100]);
-  });
-
-  it('returns the same module instance (for chaining)', () => {
-    const mod = createModule('app', []);
-    const result = mod.constant('MAX', 100);
-    expect(result).toBe(mod);
-  });
-
-  it('supports chaining with value', () => {
-    const mod = createModule('app', []).value('a', 1).constant('MAX', 5).value('b', 2);
-    expect(mod.invokeQueue.length).toBe(3);
-    expect(mod.invokeQueue[0]).toEqual(['value', 'a', 1]);
-    expect(mod.invokeQueue[1]).toEqual(['constant', 'MAX', 5]);
-    expect(mod.invokeQueue[2]).toEqual(['value', 'b', 2]);
-  });
-});
-
-describe('Module.factory', () => {
-  beforeEach(() => {
-    resetRegistry();
-  });
-
-  it('pushes [factory, name, invokable] to invokeQueue (array-style)', () => {
-    const invokable = ['dep', (dep: unknown) => ({ dep })] as const;
-    const mod = createModule('app', []).factory('myService', invokable);
-    expect(mod.invokeQueue).toHaveLength(1);
-    const entry = mod.invokeQueue[0];
-    expect(entry?.[0]).toBe('factory');
-    expect(entry?.[1]).toBe('myService');
-    expect(entry?.[2]).toBe(invokable);
-  });
-
-  it('pushes [factory, name, invokable] to invokeQueue ($inject-annotated)', () => {
-    function makeService(dep: unknown) {
-      return { dep };
-    }
-    makeService.$inject = ['dep'];
-    const mod = createModule('app', []).factory('myService', makeService);
-    expect(mod.invokeQueue).toHaveLength(1);
-    const entry = mod.invokeQueue[0];
-    expect(entry?.[0]).toBe('factory');
-    expect(entry?.[1]).toBe('myService');
-    expect(entry?.[2]).toBe(makeService);
-  });
-
-  it('returns the same module instance (for chaining)', () => {
-    const mod = createModule('app', []);
-    const chained = mod.factory('myService', [() => ({})]);
-    expect(chained).toBe(mod);
-  });
-
-  it('supports chaining with value and constant', () => {
-    const mod = createModule('app', [])
-      .value('v', 1)
-      .constant('c', 2)
-      .factory('f', [() => 'result']);
-    expect(mod.invokeQueue).toHaveLength(3);
-    expect(mod.invokeQueue[0]?.[0]).toBe('value');
-    expect(mod.invokeQueue[1]?.[0]).toBe('constant');
-    expect(mod.invokeQueue[2]?.[0]).toBe('factory');
-  });
-});
-
-describe('createInjector (values and constants)', () => {
-  beforeEach(() => {
-    resetRegistry();
-  });
-
-  it('creates an injector from a single module', () => {
-    const mod = createModule('app', []).value('url', 'https://example.com');
-    const injector = createInjector([mod]);
-    expect(injector).toBeDefined();
-    expect(typeof injector.get).toBe('function');
-    expect(typeof injector.has).toBe('function');
-  });
-
-  it('injector.get(name) returns a registered value', () => {
-    const mod = createModule('app', []).value('url', 'https://example.com');
-    const injector = createInjector([mod]);
-    expect(injector.get('url')).toBe('https://example.com');
-  });
-
-  it('injector.get(name) returns a registered constant', () => {
-    const mod = createModule('app', []).constant('MAX', 100);
-    const injector = createInjector([mod]);
-    expect(injector.get('MAX')).toBe(100);
-  });
-
-  it('injector.get(name) returns the same reference on multiple calls (singleton caching)', () => {
-    const obj = { foo: 'bar' };
-    const mod = createModule('app', []).value('obj', obj);
-    const injector = createInjector([mod]);
-    const first = injector.get('obj');
-    const second = injector.get('obj');
-    expect(first).toBe(second);
-    expect(first).toBe(obj);
-  });
-
-  it('injector.get(unknown) throws "Unknown provider: <name>"', () => {
-    const injector = createInjector([createModule('app', [])]);
-    expect(() => injector.get<unknown>('foo')).toThrow('Unknown provider: foo');
-  });
-
-  it('injector.has(name) returns true for registered values', () => {
-    const mod = createModule('app', []).value('url', 'https://example.com');
-    const injector = createInjector([mod]);
-    expect(injector.has('url')).toBe(true);
-  });
-
-  it('injector.has(name) returns false for unregistered services', () => {
-    const injector = createInjector([createModule('app', [])]);
-    expect(injector.has('nonexistent')).toBe(false);
-  });
-
-  it('injector.has(name) returns true for both values and constants', () => {
-    const mod = createModule('app', []).value('url', 'https://example.com').constant('MAX', 100);
-    const injector = createInjector([mod]);
-    expect(injector.has('url')).toBe(true);
-    expect(injector.has('MAX')).toBe(true);
-  });
-});
-
-describe('createInjector (multiple modules)', () => {
-  beforeEach(() => {
-    resetRegistry();
-  });
-
-  it('merges values and constants from multiple modules', () => {
-    const a = createModule('a', []).value('aValue', 1);
-    const b = createModule('b', []).value('bValue', 2);
-    const injector = createInjector([a, b]);
-    expect(injector.get('aValue')).toBe(1);
-    expect(injector.get('bValue')).toBe(2);
-  });
-
-  it('later modules override earlier modules when the same name is registered', () => {
-    const a = createModule('a', []).value('shared', 'from a');
-    const b = createModule('b', []).value('shared', 'from b');
-    const injector = createInjector([a, b]);
-    expect(injector.get('shared')).toBe('from b');
-  });
-});
-
-describe('createInjector (module dependency graph)', () => {
-  beforeEach(() => {
-    resetRegistry();
-  });
-
-  it('loads a required module declared in `requires`', () => {
-    createModule('common', []).value('logger', 'the-logger');
-    const app = createModule('app', ['common']).value('apiUrl', 'https://...');
-    const injector = createInjector([app]);
-    // `injector.get('logger')` uses the escape-hatch runtime path because
-    // `MergeRegistries<[typeof app]>` only sees `app`'s own Registry, not
-    // `common`'s. This test verifies runtime behavior only.
-    expect(injector.get('logger')).toBe('the-logger');
-    expect(injector.get('apiUrl')).toBe('https://...');
-  });
-
-  it('loads a chain of transitive dependencies (app -> b -> c)', () => {
-    createModule('c', []).value('cValue', 'from c');
-    createModule('b', ['c']).value('bValue', 'from b');
-    const app = createModule('app', ['b']).value('appValue', 'from app');
-    const injector = createInjector([app]);
-    expect(injector.get('cValue')).toBe('from c');
-    expect(injector.get('bValue')).toBe('from b');
-    expect(injector.get('appValue')).toBe('from app');
-  });
-
-  it('loads a shared dependency only once (diamond)', () => {
-    // Reference-identity check on the shared value proves it wasn't
-    // re-drained as a second entry under a different binding.
-    const sharedMarker = { marker: 'shared' };
-    createModule('common', []).value('shared', sharedMarker);
-    createModule('a', ['common']).value('aValue', 1);
-    createModule('b', ['common']).value('bValue', 2);
-    const app = createModule('app', ['a', 'b']).value('appValue', 3);
-    const injector = createInjector([app]);
-    expect(injector.get('shared')).toBe(sharedMarker);
-    expect(injector.get('aValue')).toBe(1);
-    expect(injector.get('bValue')).toBe(2);
-    expect(injector.get('appValue')).toBe(3);
-  });
-
-  it('drains dependencies before their dependents (post-order)', () => {
-    createModule('common', []).value('config', 'common-config');
-    const app = createModule('app', ['common']).value('config', 'app-config');
-    const injector = createInjector([app]);
-    // app.value runs AFTER common.value, so app wins.
-    expect(injector.get('config')).toBe('app-config');
-  });
-
-  it('throws when a required module is not registered', () => {
-    const app = createModule('app', ['nonexistent']).value('apiUrl', 'https://...');
-    expect(() => createInjector([app])).toThrow('Module not found: nonexistent');
-  });
-
-  it('throws when a transitive required module is not registered', () => {
-    createModule('b', ['nonexistent']).value('bValue', 'from b');
-    const app = createModule('app', ['b']);
-    expect(() => createInjector([app])).toThrow('Module not found: nonexistent');
-  });
-
-  it('handles circular module dependencies without infinite loop', () => {
-    // Two-phase setup: `createModule` only records the `requires` list; the
-    // other module only needs to exist in the registry at injector-load time.
-    createModule('a', ['b']).value('aValue', 'from a');
-    createModule('b', ['a']).value('bValue', 'from b');
-    const a = getModule('a');
-    const injector = createInjector([a]);
-    expect(injector.get('aValue')).toBe('from a');
-    expect(injector.get('bValue')).toBe('from b');
-  });
-
-  it('loads multiple root modules with overlapping dep graphs', () => {
-    createModule('common', []).value('common', 'shared');
-    const featA = createModule('featA', ['common']).value('a', 1);
-    const featB = createModule('featB', ['common']).value('b', 2);
-    const injector = createInjector([featA, featB]);
-    expect(injector.get('common')).toBe('shared');
-    expect(injector.get('a')).toBe(1);
-    expect(injector.get('b')).toBe(2);
-  });
-});
-
-describe('createInjector (factories)', () => {
-  beforeEach(() => {
-    resetRegistry();
-  });
-
-  it('invokes a factory with no dependencies and returns its result', () => {
-    const mod = createModule('app', []).factory('greeting', [() => 'hello']);
-    const injector = createInjector([mod]);
-    expect(injector.get('greeting')).toBe('hello');
-  });
-
-  it('invokes a $inject-annotated factory function', () => {
-    function makeGreeting() {
-      return 'hello';
-    }
-    makeGreeting.$inject = [] as string[];
-    const mod = createModule('app', []).factory('greeting', makeGreeting);
-    const injector = createInjector([mod]);
-    expect(injector.get('greeting')).toBe('hello');
-  });
-
-  it('invokes a factory with a value dependency (array-style)', () => {
-    const mod = createModule('app', [])
-      .value('name', 'World')
-      .factory('greeting', ['name', (name: string) => `hello ${name}`]);
-    const injector = createInjector([mod]);
-    expect(injector.get('greeting')).toBe('hello World');
-  });
-
-  it('invokes a factory with a value dependency ($inject-annotated)', () => {
-    function makeGreeting(name: string) {
-      return `hello ${name}`;
-    }
-    makeGreeting.$inject = ['name'];
-    const mod = createModule('app', []).value('name', 'World').factory('greeting', makeGreeting);
-    const injector = createInjector([mod]);
-    expect(injector.get('greeting')).toBe('hello World');
-  });
-
-  it('invokes a factory with multiple dependencies', () => {
-    const mod = createModule('app', [])
-      .value('first', 'Jane')
-      .value('last', 'Doe')
-      .factory('fullName', ['first', 'last', (f: string, l: string) => `${f} ${l}`]);
-    const injector = createInjector([mod]);
-    expect(injector.get('fullName')).toBe('Jane Doe');
-  });
-
-  it('invokes a factory that depends on another factory', () => {
-    const mod = createModule('app', [])
-      .factory('dep', [() => 'dep-value'])
-      .factory('consumer', ['dep', (d: string) => `consumer(${d})`]);
-    const injector = createInjector([mod]);
-    expect(injector.get('consumer')).toBe('consumer(dep-value)');
-  });
-
-  it('caches factory result (singleton) — invokes only once', () => {
-    const factoryFn = vi.fn(() => ({ id: Math.random() }));
-    const mod = createModule('app', []).factory('svc', [factoryFn]);
-    const injector = createInjector([mod]);
-    const first = injector.get('svc');
-    const second = injector.get('svc');
-    expect(first).toBe(second);
-    expect(factoryFn).toHaveBeenCalledTimes(1);
-  });
-
-  it('does not invoke factory at load time (lazy)', () => {
-    const factoryFn = vi.fn(() => 'value');
-    const mod = createModule('app', []).factory('svc', [factoryFn]);
-    createInjector([mod]);
-    expect(factoryFn).not.toHaveBeenCalled();
-  });
-
-  it('invokes factory only on first `get` call', () => {
-    const factoryFn = vi.fn(() => 'value');
-    const mod = createModule('app', []).factory('svc', [factoryFn]);
-    const injector = createInjector([mod]);
-    expect(factoryFn).not.toHaveBeenCalled();
-    injector.get('svc');
-    expect(factoryFn).toHaveBeenCalledTimes(1);
-  });
-
-  it('`injector.has` returns true for a registered factory (before and after invocation)', () => {
-    const mod = createModule('app', []).factory('svc', [() => 'value']);
-    const injector = createInjector([mod]);
-    expect(injector.has('svc')).toBe(true);
-    injector.get('svc');
-    expect(injector.has('svc')).toBe(true);
-  });
-
-  it('throws "Unknown provider" when get is called for an unregistered factory', () => {
-    const injector = createInjector([]);
-    expect(() => injector.get('nonexistent' as string)).toThrow('Unknown provider: nonexistent');
-  });
-
-  it('factory from a dep module is resolved when the dep module is loaded via requires', () => {
-    createModule('common', []).factory('logger', [() => ({ log: () => undefined })]);
-    const app = createModule('app', ['common']).value('apiUrl', 'https://example.com');
-    const injector = createInjector([app]);
-    const logger = injector.get<{ log: () => void }>('logger');
-    expect(logger).toBeDefined();
-    expect(logger.log).toBeInstanceOf(Function);
-  });
-});
-
-describe('type safety', () => {
-  beforeEach(() => {
-    resetRegistry();
-  });
-
-  it('module.value infers the value type (string)', () => {
-    const m = createModule('app', []).value('apiUrl', 'https://example.com');
-    const injector = createInjector([m]);
-    expectTypeOf(injector.get('apiUrl')).toEqualTypeOf<string>();
-  });
-
-  it('module.constant infers the value type (number)', () => {
-    const m = createModule('app', []).constant('MAX', 5);
-    const injector = createInjector([m]);
-    expectTypeOf(injector.get('MAX')).toEqualTypeOf<number>();
-  });
-
-  it('chained value and constant widen the registry correctly', () => {
-    const m = createModule('app', [])
-      .value('apiUrl', 'https://example.com')
-      .value('timeout', 30)
-      .constant('MAX', 5);
-    const injector = createInjector([m]);
-    expectTypeOf(injector.get('apiUrl')).toEqualTypeOf<string>();
-    expectTypeOf(injector.get('timeout')).toEqualTypeOf<number>();
-    expectTypeOf(injector.get('MAX')).toEqualTypeOf<number>();
-  });
-
-  it('object values preserve their shape', () => {
-    const m = createModule('app', []).value('config', { timeout: 30, retries: 3 });
-    const injector = createInjector([m]);
-    expectTypeOf(injector.get('config')).toEqualTypeOf<{ timeout: number; retries: number }>();
-  });
-
-  it('function values preserve their signature', () => {
-    const m = createModule('app', []).value('logger', (msg: string) => {
-      void msg;
+  describe('Module.value', () => {
+    beforeEach(() => {
+      resetRegistry();
     });
-    const injector = createInjector([m]);
-    expectTypeOf(injector.get('logger')).toEqualTypeOf<(msg: string) => void>();
-  });
 
-  it('multiple modules merge registries correctly', () => {
-    const a = createModule('a', []).value('aValue', 'from a');
-    const b = createModule('b', []).value('bValue', 42);
-    const injector = createInjector([a, b]);
-    expectTypeOf(injector.get('aValue')).toEqualTypeOf<string>();
-    expectTypeOf(injector.get('bValue')).toEqualTypeOf<number>();
-  });
-
-  it('escape-hatch generic get<T> works for dynamic-name lookups', () => {
-    const m = createModule('app', []).value('apiUrl', 'https://example.com');
-    const injector = createInjector([m]);
-    // Register a dynamic value under an unknown name via the typed path first,
-    // then retrieve it through the escape-hatch overload with an explicit
-    // generic `T`. The escape-hatch `get<T>(name: string): T` overload is
-    // selected when the caller supplies an explicit generic and a plain
-    // `string` (not a literal keyof Registry).
-    type CustomShape = { custom: boolean };
-    const dynamicName: string = 'apiUrl';
-    const customValue = injector.get<CustomShape>(dynamicName);
-    expectTypeOf(customValue).toEqualTypeOf<CustomShape>();
-  });
-
-  it('createModule preserves the name literal', () => {
-    const m = createModule('app', []);
-    expectTypeOf(m.name).toEqualTypeOf<'app'>();
-  });
-
-  it('createModule preserves the requires tuple literal', () => {
-    const m = createModule('app', ['common', 'utils']);
-    expectTypeOf(m.requires).toEqualTypeOf<readonly ['common', 'utils']>();
-  });
-
-  it('empty requires defaults to readonly []', () => {
-    const m = createModule('app', []);
-    expectTypeOf(m.requires).toEqualTypeOf<readonly []>();
-  });
-
-  it('typed get with a registered key compiles and returns the correct type', () => {
-    const m = createModule('app', []).value('apiUrl', 'https://example.com');
-    const injector = createInjector([m]);
-    // This line must compile without error -- 'apiUrl' is a statically-known
-    // key of the merged registry and picks the typed `get` overload.
-    const url = injector.get('apiUrl');
-    expectTypeOf(url).toEqualTypeOf<string>();
-  });
-
-  it('typed get with an unregistered key is rejected by the typed overload', () => {
-    const m = createModule('app', []).value('apiUrl', 'https://example.com');
-    const injector = createInjector([m]);
-    // Isolate the typed overload from the `Injector` interface so that
-    // overload resolution cannot fall through to the escape-hatch
-    // `get<T>(name: string): T`. Once extracted as a standalone function
-    // type, only the `K extends keyof Registry` signature is visible, so
-    // passing an unregistered literal key is a compile error.
-    type Registry = { apiUrl: string };
-    type TypedGet = <K extends keyof Registry>(name: K) => Registry[K];
-    const typedGet: TypedGet = injector.get.bind(injector);
-    // Positive check: a registered key compiles and returns the correct type.
-    expectTypeOf(typedGet('apiUrl')).toEqualTypeOf<string>();
-    // Negative check: an unregistered literal key is a compile error on the
-    // typed overload. The runtime call throws "Unknown provider", which we
-    // catch so the test still completes — only the compile-time
-    // `@ts-expect-error` assertion matters here.
-    try {
-      // @ts-expect-error -- 'nonexistent' is not in the typed registry
-      typedGet('nonexistent');
-    } catch {
-      /* expected: runtime throws on unregistered name */
-    }
-  });
-
-  it('services from a dep module are typed when all modules are passed to createInjector', () => {
-    const common = createModule('common', []).value('logger', {
-      log: (m: string): undefined => {
-        void m;
-        return undefined;
-      },
+    it('pushes [value, name, value] to the invokeQueue', () => {
+      const mod = createModule('app', []);
+      mod.value('apiUrl', 'https://example.com');
+      expect(mod.invokeQueue[0]).toEqual(['value', 'apiUrl', 'https://example.com']);
     });
-    const app = createModule('app', ['common']).value('apiUrl', 'https://example.com');
-    // Pass BOTH modules so MergeRegistries can union their Registry type params
-    const injector = createInjector([common, app]);
-    expectTypeOf(injector.get('logger')).toEqualTypeOf<{ log: (m: string) => undefined }>();
-    expectTypeOf(injector.get('apiUrl')).toEqualTypeOf<string>();
+
+    it('returns the same module instance (for chaining)', () => {
+      const mod = createModule('app', []);
+      const result = mod.value('x', 1);
+      expect(result).toBe(mod);
+    });
+
+    it('supports chaining multiple value calls', () => {
+      const mod = createModule('app', []).value('a', 1).value('b', 2).value('c', 3);
+      expect(mod.invokeQueue.length).toBe(3);
+      expect(mod.invokeQueue[0]).toEqual(['value', 'a', 1]);
+      expect(mod.invokeQueue[1]).toEqual(['value', 'b', 2]);
+      expect(mod.invokeQueue[2]).toEqual(['value', 'c', 3]);
+    });
+
+    it('accepts a string value', () => {
+      const mod = createModule('app', []).value('s', 'hello');
+      expect(mod.invokeQueue[0]).toEqual(['value', 's', 'hello']);
+    });
+
+    it('accepts a number value', () => {
+      const mod = createModule('app', []).value('n', 42);
+      expect(mod.invokeQueue[0]).toEqual(['value', 'n', 42]);
+    });
+
+    it('accepts a boolean value', () => {
+      const mod = createModule('app', []).value('b', true);
+      expect(mod.invokeQueue[0]).toEqual(['value', 'b', true]);
+    });
+
+    it('accepts an object value (preserving reference identity)', () => {
+      const obj = { key: 'value' };
+      const mod = createModule('app', []).value('o', obj);
+      const entry = mod.invokeQueue[0];
+      expect(entry).toEqual(['value', 'o', obj]);
+      expect(entry).toBeDefined();
+      if (entry !== undefined) {
+        expect(entry[2]).toBe(obj);
+      }
+    });
+
+    it('accepts an array value (preserving reference identity)', () => {
+      const arr = [1, 2, 3];
+      const mod = createModule('app', []).value('a', arr);
+      const entry = mod.invokeQueue[0];
+      expect(entry).toEqual(['value', 'a', arr]);
+      expect(entry).toBeDefined();
+      if (entry !== undefined) {
+        expect(entry[2]).toBe(arr);
+      }
+    });
+
+    it('accepts a null value', () => {
+      const mod = createModule('app', []).value('nully', null);
+      expect(mod.invokeQueue[0]).toEqual(['value', 'nully', null]);
+    });
+
+    it('accepts an undefined value', () => {
+      const mod = createModule('app', []).value('undef', undefined);
+      expect(mod.invokeQueue[0]).toEqual(['value', 'undef', undefined]);
+    });
+
+    it('replaces an existing value when the same name is registered twice (later wins at injector drain)', () => {
+      const mod = createModule('app', []).value('x', 1).value('x', 2);
+      expect(mod.invokeQueue.length).toBe(2);
+      expect(mod.invokeQueue[0]).toEqual(['value', 'x', 1]);
+      expect(mod.invokeQueue[1]).toEqual(['value', 'x', 2]);
+
+      const injector = createInjector([mod]);
+      expect(injector.get('x')).toBe(2);
+    });
   });
 
-  it('services from multiple dep modules all merge into the injector type', () => {
-    const a = createModule('a', []).value('aValue', 'from a');
-    const b = createModule('b', []).value('bValue', 42);
-    const c = createModule('c', []).value('cValue', true);
-    const app = createModule('app', ['a', 'b', 'c']).value('appValue', [1, 2, 3]);
-    const injector = createInjector([a, b, c, app]);
-    expectTypeOf(injector.get('aValue')).toEqualTypeOf<string>();
-    expectTypeOf(injector.get('bValue')).toEqualTypeOf<number>();
-    expectTypeOf(injector.get('cValue')).toEqualTypeOf<boolean>();
-    expectTypeOf(injector.get('appValue')).toEqualTypeOf<number[]>();
+  describe('Module.constant', () => {
+    beforeEach(() => {
+      resetRegistry();
+    });
+
+    it('pushes [constant, name, value] to the invokeQueue', () => {
+      const mod = createModule('app', []);
+      mod.constant('MAX', 100);
+      expect(mod.invokeQueue[0]).toEqual(['constant', 'MAX', 100]);
+    });
+
+    it('returns the same module instance (for chaining)', () => {
+      const mod = createModule('app', []);
+      const result = mod.constant('MAX', 100);
+      expect(result).toBe(mod);
+    });
+
+    it('supports chaining with value', () => {
+      const mod = createModule('app', []).value('a', 1).constant('MAX', 5).value('b', 2);
+      expect(mod.invokeQueue.length).toBe(3);
+      expect(mod.invokeQueue[0]).toEqual(['value', 'a', 1]);
+      expect(mod.invokeQueue[1]).toEqual(['constant', 'MAX', 5]);
+      expect(mod.invokeQueue[2]).toEqual(['value', 'b', 2]);
+    });
   });
 
-  it('services only available via runtime dep walking use the escape-hatch type', () => {
-    createModule('common', []).value('runtimeOnly', 'visible at runtime');
-    const app = createModule('app', ['common']).value('apiUrl', 'https://example.com');
-    // Only `app` is passed to createInjector
-    const injector = createInjector([app]);
-    // Typed path: works for app's own services
-    expectTypeOf(injector.get('apiUrl')).toEqualTypeOf<string>();
-    // Escape-hatch path: runtimeOnly is loaded at runtime but NOT in the typed
-    // registry of `[app]`. The typed `get<K extends keyof Registry>` overload
-    // doesn't match because 'runtimeOnly' isn't a statically-known key, so
-    // lookups fall through to the escape-hatch `get<T>(name: string): T`. We
-    // ask for a concrete branded shape that clearly is not assignable to
-    // `keyof Registry` so overload resolution lands on the escape hatch.
-    type RuntimeOnly = { readonly __runtimeOnly: string };
-    const dynamicName: string = 'runtimeOnly';
-    const runtimeValue = injector.get<RuntimeOnly>(dynamicName);
-    expectTypeOf(runtimeValue).toEqualTypeOf<RuntimeOnly>();
-    // Runtime still works because the module was loaded via requires; the
-    // value comes back as the raw string we registered, which we immediately
-    // narrow through `unknown` for the runtime assertion.
-    expect(runtimeValue as unknown).toBe('visible at runtime');
+  describe('Module.factory', () => {
+    beforeEach(() => {
+      resetRegistry();
+    });
+
+    it('pushes [factory, name, invokable] to invokeQueue (array-style)', () => {
+      const invokable = ['dep', (dep: unknown) => ({ dep })] as const;
+      const mod = createModule('app', []).factory('myService', invokable);
+      expect(mod.invokeQueue).toHaveLength(1);
+      const entry = mod.invokeQueue[0];
+      expect(entry?.[0]).toBe('factory');
+      expect(entry?.[1]).toBe('myService');
+      expect(entry?.[2]).toBe(invokable);
+    });
+
+    it('pushes [factory, name, invokable] to invokeQueue ($inject-annotated)', () => {
+      function makeService(dep: unknown) {
+        return { dep };
+      }
+      makeService.$inject = ['dep'];
+      const mod = createModule('app', []).factory('myService', makeService);
+      expect(mod.invokeQueue).toHaveLength(1);
+      const entry = mod.invokeQueue[0];
+      expect(entry?.[0]).toBe('factory');
+      expect(entry?.[1]).toBe('myService');
+      expect(entry?.[2]).toBe(makeService);
+    });
+
+    it('returns the same module instance (for chaining)', () => {
+      const mod = createModule('app', []);
+      const chained = mod.factory('myService', [() => ({})]);
+      expect(chained).toBe(mod);
+    });
+
+    it('supports chaining with value and constant', () => {
+      const mod = createModule('app', [])
+        .value('v', 1)
+        .constant('c', 2)
+        .factory('f', [() => 'result']);
+      expect(mod.invokeQueue).toHaveLength(3);
+      expect(mod.invokeQueue[0]?.[0]).toBe('value');
+      expect(mod.invokeQueue[1]?.[0]).toBe('constant');
+      expect(mod.invokeQueue[2]?.[0]).toBe('factory');
+    });
   });
 
-  it('MergeRegistries handles an empty module list', () => {
-    const injector = createInjector([]);
-    // No values registered; get should still be callable on the escape-hatch path
-    expect(() => injector.get('anything' as string)).toThrow('Unknown provider: anything');
+  describe('createInjector (values and constants)', () => {
+    beforeEach(() => {
+      resetRegistry();
+    });
+
+    it('creates an injector from a single module', () => {
+      const mod = createModule('app', []).value('url', 'https://example.com');
+      const injector = createInjector([mod]);
+      expect(injector).toBeDefined();
+      expect(typeof injector.get).toBe('function');
+      expect(typeof injector.has).toBe('function');
+    });
+
+    it('injector.get(name) returns a registered value', () => {
+      const mod = createModule('app', []).value('url', 'https://example.com');
+      const injector = createInjector([mod]);
+      expect(injector.get('url')).toBe('https://example.com');
+    });
+
+    it('injector.get(name) returns a registered constant', () => {
+      const mod = createModule('app', []).constant('MAX', 100);
+      const injector = createInjector([mod]);
+      expect(injector.get('MAX')).toBe(100);
+    });
+
+    it('injector.get(name) returns the same reference on multiple calls (singleton caching)', () => {
+      const obj = { foo: 'bar' };
+      const mod = createModule('app', []).value('obj', obj);
+      const injector = createInjector([mod]);
+      const first = injector.get('obj');
+      const second = injector.get('obj');
+      expect(first).toBe(second);
+      expect(first).toBe(obj);
+    });
+
+    it('injector.get(unknown) throws "Unknown provider: <name>"', () => {
+      const injector = createInjector([createModule('app', [])]);
+      expect(() => injector.get<unknown>('foo')).toThrow('Unknown provider: foo');
+    });
+
+    it('injector.has(name) returns true for registered values', () => {
+      const mod = createModule('app', []).value('url', 'https://example.com');
+      const injector = createInjector([mod]);
+      expect(injector.has('url')).toBe(true);
+    });
+
+    it('injector.has(name) returns false for unregistered services', () => {
+      const injector = createInjector([createModule('app', [])]);
+      expect(injector.has('nonexistent')).toBe(false);
+    });
+
+    it('injector.has(name) returns true for both values and constants', () => {
+      const mod = createModule('app', []).value('url', 'https://example.com').constant('MAX', 100);
+      const injector = createInjector([mod]);
+      expect(injector.has('url')).toBe(true);
+      expect(injector.has('MAX')).toBe(true);
+    });
   });
 
-  it('merges disjoint modules into a single typed registry', () => {
-    const core = createModule('core', []).value('version', '1.0');
-    const feat = createModule('feat', []).constant('FEATURE_FLAG', 'on' as const);
-    const injector = createInjector([core, feat]);
-    expectTypeOf(injector.get('version')).toEqualTypeOf<string>();
-    expectTypeOf(injector.get('FEATURE_FLAG')).toEqualTypeOf<'on'>();
+  describe('createInjector (multiple modules)', () => {
+    beforeEach(() => {
+      resetRegistry();
+    });
+
+    it('merges values and constants from multiple modules', () => {
+      const a = createModule('a', []).value('aValue', 1);
+      const b = createModule('b', []).value('bValue', 2);
+      const injector = createInjector([a, b]);
+      expect(injector.get('aValue')).toBe(1);
+      expect(injector.get('bValue')).toBe(2);
+    });
+
+    it('later modules override earlier modules when the same name is registered', () => {
+      const a = createModule('a', []).value('shared', 'from a');
+      const b = createModule('b', []).value('shared', 'from b');
+      const injector = createInjector([a, b]);
+      expect(injector.get('shared')).toBe('from b');
+    });
   });
 
-  it('factory with explicit generic T infers return type on injector.get', () => {
-    type Logger = { log: (m: string) => void };
-    const mod = createModule('app', []).factory<'logger', Logger>('logger', [
-      () => ({
-        log: (m: string) => {
+  describe('createInjector (module dependency graph)', () => {
+    beforeEach(() => {
+      resetRegistry();
+    });
+
+    it('loads a required module declared in `requires`', () => {
+      createModule('common', []).value('logger', 'the-logger');
+      const app = createModule('app', ['common']).value('apiUrl', 'https://...');
+      const injector = createInjector([app]);
+      // `injector.get('logger')` uses the escape-hatch runtime path because
+      // `MergeRegistries<[typeof app]>` only sees `app`'s own Registry, not
+      // `common`'s. This test verifies runtime behavior only.
+      expect(injector.get('logger')).toBe('the-logger');
+      expect(injector.get('apiUrl')).toBe('https://...');
+    });
+
+    it('loads a chain of transitive dependencies (app -> b -> c)', () => {
+      createModule('c', []).value('cValue', 'from c');
+      createModule('b', ['c']).value('bValue', 'from b');
+      const app = createModule('app', ['b']).value('appValue', 'from app');
+      const injector = createInjector([app]);
+      expect(injector.get('cValue')).toBe('from c');
+      expect(injector.get('bValue')).toBe('from b');
+      expect(injector.get('appValue')).toBe('from app');
+    });
+
+    it('loads a shared dependency only once (diamond)', () => {
+      // Reference-identity check on the shared value proves it wasn't
+      // re-drained as a second entry under a different binding.
+      const sharedMarker = { marker: 'shared' };
+      createModule('common', []).value('shared', sharedMarker);
+      createModule('a', ['common']).value('aValue', 1);
+      createModule('b', ['common']).value('bValue', 2);
+      const app = createModule('app', ['a', 'b']).value('appValue', 3);
+      const injector = createInjector([app]);
+      expect(injector.get('shared')).toBe(sharedMarker);
+      expect(injector.get('aValue')).toBe(1);
+      expect(injector.get('bValue')).toBe(2);
+      expect(injector.get('appValue')).toBe(3);
+    });
+
+    it('drains dependencies before their dependents (post-order)', () => {
+      createModule('common', []).value('config', 'common-config');
+      const app = createModule('app', ['common']).value('config', 'app-config');
+      const injector = createInjector([app]);
+      // app.value runs AFTER common.value, so app wins.
+      expect(injector.get('config')).toBe('app-config');
+    });
+
+    it('throws when a required module is not registered', () => {
+      const app = createModule('app', ['nonexistent']).value('apiUrl', 'https://...');
+      expect(() => createInjector([app])).toThrow('Module not found: nonexistent');
+    });
+
+    it('throws when a transitive required module is not registered', () => {
+      createModule('b', ['nonexistent']).value('bValue', 'from b');
+      const app = createModule('app', ['b']);
+      expect(() => createInjector([app])).toThrow('Module not found: nonexistent');
+    });
+
+    it('handles circular module dependencies without infinite loop', () => {
+      // Two-phase setup: `createModule` only records the `requires` list; the
+      // other module only needs to exist in the registry at injector-load time.
+      createModule('a', ['b']).value('aValue', 'from a');
+      createModule('b', ['a']).value('bValue', 'from b');
+      const a = getModule('a');
+      const injector = createInjector([a]);
+      expect(injector.get('aValue')).toBe('from a');
+      expect(injector.get('bValue')).toBe('from b');
+    });
+
+    it('loads multiple root modules with overlapping dep graphs', () => {
+      createModule('common', []).value('common', 'shared');
+      const featA = createModule('featA', ['common']).value('a', 1);
+      const featB = createModule('featB', ['common']).value('b', 2);
+      const injector = createInjector([featA, featB]);
+      expect(injector.get('common')).toBe('shared');
+      expect(injector.get('a')).toBe(1);
+      expect(injector.get('b')).toBe(2);
+    });
+  });
+
+  describe('createInjector (factories)', () => {
+    beforeEach(() => {
+      resetRegistry();
+    });
+
+    it('invokes a factory with no dependencies and returns its result', () => {
+      const mod = createModule('app', []).factory('greeting', [() => 'hello']);
+      const injector = createInjector([mod]);
+      expect(injector.get('greeting')).toBe('hello');
+    });
+
+    it('invokes a $inject-annotated factory function', () => {
+      function makeGreeting() {
+        return 'hello';
+      }
+      makeGreeting.$inject = [] as string[];
+      const mod = createModule('app', []).factory('greeting', makeGreeting);
+      const injector = createInjector([mod]);
+      expect(injector.get('greeting')).toBe('hello');
+    });
+
+    it('invokes a factory with a value dependency (array-style)', () => {
+      const mod = createModule('app', [])
+        .value('name', 'World')
+        .factory('greeting', ['name', (name: string) => `hello ${name}`]);
+      const injector = createInjector([mod]);
+      expect(injector.get('greeting')).toBe('hello World');
+    });
+
+    it('invokes a factory with a value dependency ($inject-annotated)', () => {
+      function makeGreeting(name: string) {
+        return `hello ${name}`;
+      }
+      makeGreeting.$inject = ['name'];
+      const mod = createModule('app', []).value('name', 'World').factory('greeting', makeGreeting);
+      const injector = createInjector([mod]);
+      expect(injector.get('greeting')).toBe('hello World');
+    });
+
+    it('invokes a factory with multiple dependencies', () => {
+      const mod = createModule('app', [])
+        .value('first', 'Jane')
+        .value('last', 'Doe')
+        .factory('fullName', ['first', 'last', (f: string, l: string) => `${f} ${l}`]);
+      const injector = createInjector([mod]);
+      expect(injector.get('fullName')).toBe('Jane Doe');
+    });
+
+    it('invokes a factory that depends on another factory', () => {
+      const mod = createModule('app', [])
+        .factory('dep', [() => 'dep-value'])
+        .factory('consumer', ['dep', (d: string) => `consumer(${d})`]);
+      const injector = createInjector([mod]);
+      expect(injector.get('consumer')).toBe('consumer(dep-value)');
+    });
+
+    it('caches factory result (singleton) — invokes only once', () => {
+      const factoryFn = vi.fn(() => ({ id: Math.random() }));
+      const mod = createModule('app', []).factory('svc', [factoryFn]);
+      const injector = createInjector([mod]);
+      const first = injector.get('svc');
+      const second = injector.get('svc');
+      expect(first).toBe(second);
+      expect(factoryFn).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not invoke factory at load time (lazy)', () => {
+      const factoryFn = vi.fn(() => 'value');
+      const mod = createModule('app', []).factory('svc', [factoryFn]);
+      createInjector([mod]);
+      expect(factoryFn).not.toHaveBeenCalled();
+    });
+
+    it('invokes factory only on first `get` call', () => {
+      const factoryFn = vi.fn(() => 'value');
+      const mod = createModule('app', []).factory('svc', [factoryFn]);
+      const injector = createInjector([mod]);
+      expect(factoryFn).not.toHaveBeenCalled();
+      injector.get('svc');
+      expect(factoryFn).toHaveBeenCalledTimes(1);
+    });
+
+    it('`injector.has` returns true for a registered factory (before and after invocation)', () => {
+      const mod = createModule('app', []).factory('svc', [() => 'value']);
+      const injector = createInjector([mod]);
+      expect(injector.has('svc')).toBe(true);
+      injector.get('svc');
+      expect(injector.has('svc')).toBe(true);
+    });
+
+    it('throws "Unknown provider" when get is called for an unregistered factory', () => {
+      const injector = createInjector([]);
+      expect(() => injector.get('nonexistent' as string)).toThrow('Unknown provider: nonexistent');
+    });
+
+    it('factory from a dep module is resolved when the dep module is loaded via requires', () => {
+      createModule('common', []).factory('logger', [() => ({ log: () => undefined })]);
+      const app = createModule('app', ['common']).value('apiUrl', 'https://example.com');
+      const injector = createInjector([app]);
+      const logger = injector.get<{ log: () => void }>('logger');
+      expect(logger).toBeDefined();
+      expect(logger.log).toBeInstanceOf(Function);
+    });
+  });
+
+  describe('type safety', () => {
+    beforeEach(() => {
+      resetRegistry();
+    });
+
+    it('module.value infers the value type (string)', () => {
+      const m = createModule('app', []).value('apiUrl', 'https://example.com');
+      const injector = createInjector([m]);
+      expectTypeOf(injector.get('apiUrl')).toEqualTypeOf<string>();
+    });
+
+    it('module.constant infers the value type (number)', () => {
+      const m = createModule('app', []).constant('MAX', 5);
+      const injector = createInjector([m]);
+      expectTypeOf(injector.get('MAX')).toEqualTypeOf<number>();
+    });
+
+    it('chained value and constant widen the registry correctly', () => {
+      const m = createModule('app', []).value('apiUrl', 'https://example.com').value('timeout', 30).constant('MAX', 5);
+      const injector = createInjector([m]);
+      expectTypeOf(injector.get('apiUrl')).toEqualTypeOf<string>();
+      expectTypeOf(injector.get('timeout')).toEqualTypeOf<number>();
+      expectTypeOf(injector.get('MAX')).toEqualTypeOf<number>();
+    });
+
+    it('object values preserve their shape', () => {
+      const m = createModule('app', []).value('config', { timeout: 30, retries: 3 });
+      const injector = createInjector([m]);
+      expectTypeOf(injector.get('config')).toEqualTypeOf<{ timeout: number; retries: number }>();
+    });
+
+    it('function values preserve their signature', () => {
+      const m = createModule('app', []).value('logger', (msg: string) => {
+        void msg;
+      });
+      const injector = createInjector([m]);
+      expectTypeOf(injector.get('logger')).toEqualTypeOf<(msg: string) => void>();
+    });
+
+    it('multiple modules merge registries correctly', () => {
+      const a = createModule('a', []).value('aValue', 'from a');
+      const b = createModule('b', []).value('bValue', 42);
+      const injector = createInjector([a, b]);
+      expectTypeOf(injector.get('aValue')).toEqualTypeOf<string>();
+      expectTypeOf(injector.get('bValue')).toEqualTypeOf<number>();
+    });
+
+    it('escape-hatch generic get<T> works for dynamic-name lookups', () => {
+      const m = createModule('app', []).value('apiUrl', 'https://example.com');
+      const injector = createInjector([m]);
+      // Register a dynamic value under an unknown name via the typed path first,
+      // then retrieve it through the escape-hatch overload with an explicit
+      // generic `T`. The escape-hatch `get<T>(name: string): T` overload is
+      // selected when the caller supplies an explicit generic and a plain
+      // `string` (not a literal keyof Registry).
+      type CustomShape = { custom: boolean };
+      const dynamicName: string = 'apiUrl';
+      const customValue = injector.get<CustomShape>(dynamicName);
+      expectTypeOf(customValue).toEqualTypeOf<CustomShape>();
+    });
+
+    it('createModule preserves the name literal', () => {
+      const m = createModule('app', []);
+      expectTypeOf(m.name).toEqualTypeOf<'app'>();
+    });
+
+    it('createModule preserves the requires tuple literal', () => {
+      const m = createModule('app', ['common', 'utils']);
+      expectTypeOf(m.requires).toEqualTypeOf<readonly ['common', 'utils']>();
+    });
+
+    it('empty requires defaults to readonly []', () => {
+      const m = createModule('app', []);
+      expectTypeOf(m.requires).toEqualTypeOf<readonly []>();
+    });
+
+    it('typed get with a registered key compiles and returns the correct type', () => {
+      const m = createModule('app', []).value('apiUrl', 'https://example.com');
+      const injector = createInjector([m]);
+      // This line must compile without error -- 'apiUrl' is a statically-known
+      // key of the merged registry and picks the typed `get` overload.
+      const url = injector.get('apiUrl');
+      expectTypeOf(url).toEqualTypeOf<string>();
+    });
+
+    it('typed get with an unregistered key is rejected by the typed overload', () => {
+      const m = createModule('app', []).value('apiUrl', 'https://example.com');
+      const injector = createInjector([m]);
+      // Isolate the typed overload from the `Injector` interface so that
+      // overload resolution cannot fall through to the escape-hatch
+      // `get<T>(name: string): T`. Once extracted as a standalone function
+      // type, only the `K extends keyof Registry` signature is visible, so
+      // passing an unregistered literal key is a compile error.
+      type Registry = { apiUrl: string };
+      type TypedGet = <K extends keyof Registry>(name: K) => Registry[K];
+      const typedGet: TypedGet = injector.get.bind(injector);
+      // Positive check: a registered key compiles and returns the correct type.
+      expectTypeOf(typedGet('apiUrl')).toEqualTypeOf<string>();
+      // Negative check: an unregistered literal key is a compile error on the
+      // typed overload. The runtime call throws "Unknown provider", which we
+      // catch so the test still completes — only the compile-time
+      // `@ts-expect-error` assertion matters here.
+      try {
+        // @ts-expect-error -- 'nonexistent' is not in the typed registry
+        typedGet('nonexistent');
+      } catch {
+        /* expected: runtime throws on unregistered name */
+      }
+    });
+
+    it('services from a dep module are typed when all modules are passed to createInjector', () => {
+      const common = createModule('common', []).value('logger', {
+        log: (m: string): undefined => {
           void m;
+          return undefined;
         },
-      }),
-    ]);
-    const injector = createInjector([mod]);
-    expectTypeOf(injector.get('logger')).toEqualTypeOf<Logger>();
-  });
+      });
+      const app = createModule('app', ['common']).value('apiUrl', 'https://example.com');
+      // Pass BOTH modules so MergeRegistries can union their Registry type params
+      const injector = createInjector([common, app]);
+      expectTypeOf(injector.get('logger')).toEqualTypeOf<{ log: (m: string) => undefined }>();
+      expectTypeOf(injector.get('apiUrl')).toEqualTypeOf<string>();
+    });
 
-  it('factory infers return type from invokable when no explicit generic is provided', () => {
-    const mod = createModule('app', []).factory('svc', [() => ({ foo: 'bar' })]);
-    const injector = createInjector([mod]);
-    expectTypeOf(injector.get('svc')).toEqualTypeOf<{ foo: string }>();
-  });
+    it('services from multiple dep modules all merge into the injector type', () => {
+      const a = createModule('a', []).value('aValue', 'from a');
+      const b = createModule('b', []).value('bValue', 42);
+      const c = createModule('c', []).value('cValue', true);
+      const app = createModule('app', ['a', 'b', 'c']).value('appValue', [1, 2, 3]);
+      const injector = createInjector([a, b, c, app]);
+      expectTypeOf(injector.get('aValue')).toEqualTypeOf<string>();
+      expectTypeOf(injector.get('bValue')).toEqualTypeOf<number>();
+      expectTypeOf(injector.get('cValue')).toEqualTypeOf<boolean>();
+      expectTypeOf(injector.get('appValue')).toEqualTypeOf<number[]>();
+    });
 
-  it('factory merges into registry alongside value and constant', () => {
-    type Greeter = { hello: () => string };
-    const mod = createModule('app', [])
-      .value('name', 'World')
-      .constant('PREFIX', '>>')
-      .factory<'greeter', Greeter>('greeter', [
-        'name',
-        (name: string): Greeter => ({ hello: () => `hi ${name}` }),
+    it('services only available via runtime dep walking use the escape-hatch type', () => {
+      createModule('common', []).value('runtimeOnly', 'visible at runtime');
+      const app = createModule('app', ['common']).value('apiUrl', 'https://example.com');
+      // Only `app` is passed to createInjector
+      const injector = createInjector([app]);
+      // Typed path: works for app's own services
+      expectTypeOf(injector.get('apiUrl')).toEqualTypeOf<string>();
+      // Escape-hatch path: runtimeOnly is loaded at runtime but NOT in the typed
+      // registry of `[app]`. The typed `get<K extends keyof Registry>` overload
+      // doesn't match because 'runtimeOnly' isn't a statically-known key, so
+      // lookups fall through to the escape-hatch `get<T>(name: string): T`. We
+      // ask for a concrete branded shape that clearly is not assignable to
+      // `keyof Registry` so overload resolution lands on the escape hatch.
+      type RuntimeOnly = { readonly __runtimeOnly: string };
+      const dynamicName: string = 'runtimeOnly';
+      const runtimeValue = injector.get<RuntimeOnly>(dynamicName);
+      expectTypeOf(runtimeValue).toEqualTypeOf<RuntimeOnly>();
+      // Runtime still works because the module was loaded via requires; the
+      // value comes back as the raw string we registered, which we immediately
+      // narrow through `unknown` for the runtime assertion.
+      expect(runtimeValue as unknown).toBe('visible at runtime');
+    });
+
+    it('MergeRegistries handles an empty module list', () => {
+      const injector = createInjector([]);
+      // No values registered; get should still be callable on the escape-hatch path
+      expect(() => injector.get('anything' as string)).toThrow('Unknown provider: anything');
+    });
+
+    it('merges disjoint modules into a single typed registry', () => {
+      const core = createModule('core', []).value('version', '1.0');
+      const feat = createModule('feat', []).constant('FEATURE_FLAG', 'on' as const);
+      const injector = createInjector([core, feat]);
+      expectTypeOf(injector.get('version')).toEqualTypeOf<string>();
+      expectTypeOf(injector.get('FEATURE_FLAG')).toEqualTypeOf<'on'>();
+    });
+
+    it('factory with explicit generic T infers return type on injector.get', () => {
+      type Logger = { log: (m: string) => void };
+      const mod = createModule('app', []).factory<'logger', Logger>('logger', [
+        () => ({
+          log: (m: string) => {
+            void m;
+          },
+        }),
       ]);
-    const injector = createInjector([mod]);
-    expectTypeOf(injector.get('name')).toEqualTypeOf<string>();
-    expectTypeOf(injector.get('PREFIX')).toEqualTypeOf<string>();
-    expectTypeOf(injector.get('greeter')).toEqualTypeOf<Greeter>();
+      const injector = createInjector([mod]);
+      expectTypeOf(injector.get('logger')).toEqualTypeOf<Logger>();
+    });
+
+    it('factory infers return type from invokable when no explicit generic is provided', () => {
+      const mod = createModule('app', []).factory('svc', [() => ({ foo: 'bar' })]);
+      const injector = createInjector([mod]);
+      expectTypeOf(injector.get('svc')).toEqualTypeOf<{ foo: string }>();
+    });
+
+    it('factory merges into registry alongside value and constant', () => {
+      type Greeter = { hello: () => string };
+      const mod = createModule('app', [])
+        .value('name', 'World')
+        .constant('PREFIX', '>>')
+        .factory<'greeter', Greeter>('greeter', ['name', (name: string): Greeter => ({ hello: () => `hi ${name}` })]);
+      const injector = createInjector([mod]);
+      expectTypeOf(injector.get('name')).toEqualTypeOf<string>();
+      expectTypeOf(injector.get('PREFIX')).toEqualTypeOf<string>();
+      expectTypeOf(injector.get('greeter')).toEqualTypeOf<Greeter>();
+    });
+
+    it('factories from multiple modules merge into the injector type', () => {
+      type Clock = { now: () => number };
+      type Random = { next: () => number };
+      const core = createModule('core', []).factory<'clock', Clock>('clock', [() => ({ now: () => Date.now() })]);
+      const rand = createModule('rand', []).factory<'random', Random>('random', [
+        () => ({ next: () => Math.random() }),
+      ]);
+      const injector = createInjector([core, rand]);
+      expectTypeOf(injector.get('clock')).toEqualTypeOf<Clock>();
+      expectTypeOf(injector.get('random')).toEqualTypeOf<Random>();
+    });
+
+    it('$inject-annotated factory with explicit generic T infers return type', () => {
+      type Counter = { value: number };
+      function makeCounter(): Counter {
+        return { value: 0 };
+      }
+      makeCounter.$inject = [] as string[];
+      const mod = createModule('app', []).factory<'counter', Counter>('counter', makeCounter);
+      const injector = createInjector([mod]);
+      expectTypeOf(injector.get('counter')).toEqualTypeOf<Counter>();
+    });
   });
 
-  it('factories from multiple modules merge into the injector type', () => {
-    type Clock = { now: () => number };
-    type Random = { next: () => number };
-    const core = createModule('core', []).factory<'clock', Clock>('clock', [
-      () => ({ now: () => Date.now() }),
-    ]);
-    const rand = createModule('rand', []).factory<'random', Random>('random', [
-      () => ({ next: () => Math.random() }),
-    ]);
-    const injector = createInjector([core, rand]);
-    expectTypeOf(injector.get('clock')).toEqualTypeOf<Clock>();
-    expectTypeOf(injector.get('random')).toEqualTypeOf<Random>();
-  });
+  describe('typed factory DI', () => {
+    beforeEach(() => {
+      resetRegistry();
+    });
 
-  it('$inject-annotated factory with explicit generic T infers return type', () => {
-    type Counter = { value: number };
-    function makeCounter(): Counter {
-      return { value: 0 };
-    }
-    makeCounter.$inject = [] as string[];
-    const mod = createModule('app', []).factory<'counter', Counter>('counter', makeCounter);
-    const injector = createInjector([mod]);
-    expectTypeOf(injector.get('counter')).toEqualTypeOf<Counter>();
+    it('array-style typed factory infers callback param types from the registry', () => {
+      const mod = createModule('app', [])
+        .value('name', 'Jane')
+        .value('age', 30)
+        .factory('greet', [
+          'name',
+          'age',
+          (name, age) => {
+            expectTypeOf(name).toEqualTypeOf<string>();
+            expectTypeOf(age).toEqualTypeOf<number>();
+            return `${name} is ${String(age)}`;
+          },
+        ]);
+      const injector = createInjector([mod]);
+      expect(injector.get('greet')).toBe('Jane is 30');
+      expectTypeOf(injector.get('greet')).toEqualTypeOf<string>();
+    });
+
+    it('empty-deps array-style factory still compiles and types the return', () => {
+      const mod = createModule('app', []).factory('constant', [() => 42]);
+      const injector = createInjector([mod]);
+      expectTypeOf(injector.get('constant')).toEqualTypeOf<number>();
+      expect(injector.get('constant')).toBe(42);
+    });
+
+    it('$inject-annotated factory with readonly literal tuple types callback params', () => {
+      function makeGreeting(name: string): string {
+        return `hi ${name}`;
+      }
+      makeGreeting.$inject = ['name'] as const;
+      const mod = createModule('app', []).value('name', 'World').factory('greeting', makeGreeting);
+      const injector = createInjector([mod]);
+      expect(injector.get('greeting')).toBe('hi World');
+      expectTypeOf(injector.get('greeting')).toEqualTypeOf<string>();
+    });
   });
 });

--- a/src/di/__tests__/di.test.ts
+++ b/src/di/__tests__/di.test.ts
@@ -492,6 +492,96 @@ describe('dependency injection', () => {
     });
   });
 
+  describe('createInjector (circular dependency detection)', () => {
+    beforeEach(() => {
+      resetRegistry();
+    });
+
+    it('throws when a factory depends on itself directly (A -> A)', () => {
+      const mod = createModule('app', []).factory('A', ['A', (a: unknown) => a]);
+      const injector = createInjector([mod]);
+      expect(() => injector.get('A')).toThrow('Circular dependency: A <- A');
+    });
+
+    it('throws on a 2-level cycle (A -> B -> A)', () => {
+      const mod = createModule('app', [])
+        .factory('A', ['B', (b: unknown) => b])
+        .factory('B', ['A', (a: unknown) => a]);
+      const injector = createInjector([mod]);
+      expect(() => injector.get('A')).toThrow('Circular dependency: A <- B <- A');
+    });
+
+    it('throws on a 3-level cycle (A -> B -> C -> A)', () => {
+      const mod = createModule('app', [])
+        .factory('A', ['B', (b: unknown) => b])
+        .factory('B', ['C', (c: unknown) => c])
+        .factory('C', ['A', (a: unknown) => a]);
+      const injector = createInjector([mod]);
+      expect(() => injector.get('A')).toThrow('Circular dependency: A <- B <- C <- A');
+    });
+
+    it('throws on a cycle detected from a non-root entry point', () => {
+      const mod = createModule('app', [])
+        .factory('A', ['B', (b: unknown) => b])
+        .factory('B', ['C', (c: unknown) => c])
+        .factory('C', ['B', (b: unknown) => b]); // B and C form a cycle
+      const injector = createInjector([mod]);
+      // Starting from A pulls in B which tries to pull in C which tries to pull in B.
+      // The full resolution path is retained; the cycle is at the tail.
+      expect(() => injector.get('A')).toThrow('Circular dependency: A <- B <- C <- B');
+    });
+
+    it('still resolves non-cyclic services when an unrelated cycle exists in the module', () => {
+      const mod = createModule('app', [])
+        .value('safe', 'ok')
+        .factory('A', ['B', (b: unknown) => b])
+        .factory('B', ['A', (a: unknown) => a]);
+      const injector = createInjector([mod]);
+      // The safe value is accessible
+      expect(injector.get('safe')).toBe('ok');
+      // Touching the cycle still throws
+      expect(() => injector.get('A')).toThrow(/Circular dependency/);
+    });
+
+    it('error message includes the full dependency chain', () => {
+      const mod = createModule('app', [])
+        .factory('A', ['B', (b: unknown) => b])
+        .factory('B', ['C', (c: unknown) => c])
+        .factory('C', ['A', (a: unknown) => a]);
+      const injector = createInjector([mod]);
+      try {
+        injector.get('A');
+        expect.fail('expected injector.get to throw');
+      } catch (err) {
+        expect(err).toBeInstanceOf(Error);
+        expect((err as Error).message).toContain('Circular dependency:');
+        expect((err as Error).message).toContain('A');
+        expect((err as Error).message).toContain('B');
+        expect((err as Error).message).toContain('C');
+      }
+    });
+
+    it('detects a cycle when invoke triggers the resolution', () => {
+      const mod = createModule('app', [])
+        .factory('A', ['B', (b: unknown) => b])
+        .factory('B', ['A', (a: unknown) => a]);
+      const injector = createInjector([mod]);
+      expect(() => injector.invoke(['A', (a: unknown) => a])).toThrow(/Circular dependency/);
+    });
+
+    it('does not leak the resolution path after a cycle error', () => {
+      const mod = createModule('app', [])
+        .value('safe', 'ok')
+        .factory('A', ['B', (b: unknown) => b])
+        .factory('B', ['A', (a: unknown) => a]);
+      const injector = createInjector([mod]);
+      // First call throws
+      expect(() => injector.get('A')).toThrow(/Circular dependency/);
+      // Subsequent call for an unrelated service still works
+      expect(injector.get('safe')).toBe('ok');
+    });
+  });
+
   describe('injector.invoke / annotate', () => {
     beforeEach(() => {
       resetRegistry();

--- a/src/di/__tests__/di.test.ts
+++ b/src/di/__tests__/di.test.ts
@@ -492,6 +492,150 @@ describe('dependency injection', () => {
     });
   });
 
+  describe('injector.invoke / annotate', () => {
+    beforeEach(() => {
+      resetRegistry();
+    });
+
+    it('invokes an array-style invokable with resolved dependencies', () => {
+      const mod = createModule('app', []).value('name', 'Jane');
+      const injector = createInjector([mod]);
+      const result = injector.invoke(['name', (name) => `hello ${name}`]);
+      expect(result).toBe('hello Jane');
+    });
+
+    it('invokes a $inject-annotated function with resolved dependencies', () => {
+      function greet(name: string) {
+        return `hi ${name}`;
+      }
+      greet.$inject = ['name'] as const;
+      const mod = createModule('app', []).value('name', 'Jane');
+      const injector = createInjector([mod]);
+      expect(injector.invoke(greet)).toBe('hi Jane');
+    });
+
+    it('resolves multiple dependencies in order', () => {
+      const mod = createModule('app', []).value('first', 'Jane').value('last', 'Doe');
+      const injector = createInjector([mod]);
+      const result = injector.invoke(['first', 'last', (f: string, l: string) => `${f} ${l}`]);
+      expect(result).toBe('Jane Doe');
+    });
+
+    it('binds `this` to the provided self argument', () => {
+      const injector = createInjector([]);
+      const ctx = { label: 'context' };
+      function getLabel(this: { label: string }) {
+        return this.label;
+      }
+      getLabel.$inject = [] as readonly string[];
+      expect(injector.invoke(getLabel, ctx)).toBe('context');
+    });
+
+    it('uses locals override when the dep name is present in locals', () => {
+      const mod = createModule('app', []).value('name', 'Jane');
+      const injector = createInjector([mod]);
+      const result = injector.invoke(
+        ['name', (name) => `hello ${name}`],
+        null,
+        { name: 'Bob' },
+      );
+      expect(result).toBe('hello Bob');
+    });
+
+    it('respects an explicit undefined in locals (hasOwnProperty check)', () => {
+      const mod = createModule('app', []).value('name', 'Jane');
+      const injector = createInjector([mod]);
+      const result = injector.invoke(
+        ['name', (name) => name],
+        null,
+        { name: undefined },
+      );
+      expect(result).toBeUndefined();
+    });
+
+    it('falls through to the injector when a dep is not in locals', () => {
+      const mod = createModule('app', []).value('name', 'Jane').value('age', 30);
+      const injector = createInjector([mod]);
+      const result = injector.invoke(
+        ['name', 'age', (n , a)=> `${n}:${String(a)}`],
+        null,
+        { name: 'Bob' },
+      );
+      expect(result).toBe('Bob:30');
+    });
+
+    it('invokes a function that depends on a lazy factory', () => {
+      const mod = createModule('app', [])
+        .value('base', 2)
+        .factory('doubled', ['base', (base: number) => base * 2]);
+      const injector = createInjector([mod]);
+      const result = injector.invoke(['doubled', (d: number) => d + 1]);
+      expect(result).toBe(5);
+    });
+
+    it('throws when invoking a plain function without $inject', () => {
+      const injector = createInjector([]);
+      function unannotated() {
+        return 'never';
+      }
+      expect(() => injector.invoke(unannotated)).toThrow();
+    });
+
+    it('invokes a function with no dependencies (empty array-style)', () => {
+      const injector = createInjector([]);
+      const result = injector.invoke([() => 42]);
+      expect(result).toBe(42);
+    });
+
+    it('infers callback parameter types from the registry (no manual annotation)', () => {
+      const mod = createModule('app', []).value('name', 'Jane').value('age', 30);
+      const injector = createInjector([mod]);
+      // No type annotations on (name, age) — they're inferred from the registry
+      // via the typed array-style overload on `Injector.invoke`.
+      const result = injector.invoke(['name', 'age', (name, age) => `${name} is ${String(age)}`]);
+      expect(result).toBe('Jane is 30');
+      // Type-level check: the inference produced a `string` return.
+      expectTypeOf(result).toEqualTypeOf<string>();
+    });
+
+    it('annotate returns dep names from an array-style invokable', () => {
+      const injector = createInjector([]);
+      const deps = injector.annotate(['a', 'b', 'c', (a, b , c) => [a, b, c]]);
+      expect(deps).toEqual(['a', 'b', 'c']);
+    });
+
+    it('annotate returns $inject array from an annotated function', () => {
+      const injector = createInjector([]);
+      function svc() {
+        return 42;
+      }
+      svc.$inject = ['dep1', 'dep2'] as const;
+      expect(injector.annotate(svc)).toEqual(['dep1', 'dep2']);
+    });
+
+    it('annotate returns an empty array for a no-deps array-style', () => {
+      const injector = createInjector([]);
+      expect(injector.annotate([() => 1])).toEqual([]);
+    });
+
+    it('annotate returns an empty array for a function with empty $inject', () => {
+      const injector = createInjector([]);
+      function svc() {
+        return 42;
+      }
+      svc.$inject = [] as readonly string[];
+      expect(injector.annotate(svc)).toEqual([]);
+    });
+
+    it('annotate throws for a plain function without $inject', () => {
+      const injector = createInjector([]);
+      function unannotated() {
+        return 'never';
+      }
+      expect(() => injector.annotate(unannotated)).toThrow();
+    });
+  });
+
   describe('type safety', () => {
     beforeEach(() => {
       resetRegistry();

--- a/src/di/__tests__/di.test.ts
+++ b/src/di/__tests__/di.test.ts
@@ -624,33 +624,21 @@ describe('dependency injection', () => {
     it('uses locals override when the dep name is present in locals', () => {
       const mod = createModule('app', []).value('name', 'Jane');
       const injector = createInjector([mod]);
-      const result = injector.invoke(
-        ['name', (name) => `hello ${name}`],
-        null,
-        { name: 'Bob' },
-      );
+      const result = injector.invoke(['name', (name) => `hello ${name}`], null, { name: 'Bob' });
       expect(result).toBe('hello Bob');
     });
 
     it('respects an explicit undefined in locals (hasOwnProperty check)', () => {
       const mod = createModule('app', []).value('name', 'Jane');
       const injector = createInjector([mod]);
-      const result = injector.invoke(
-        ['name', (name) => name],
-        null,
-        { name: undefined },
-      );
+      const result = injector.invoke(['name', (name) => name], null, { name: undefined });
       expect(result).toBeUndefined();
     });
 
     it('falls through to the injector when a dep is not in locals', () => {
       const mod = createModule('app', []).value('name', 'Jane').value('age', 30);
       const injector = createInjector([mod]);
-      const result = injector.invoke(
-        ['name', 'age', (n , a)=> `${n}:${String(a)}`],
-        null,
-        { name: 'Bob' },
-      );
+      const result = injector.invoke(['name', 'age', (n, a) => `${n}:${String(a)}`], null, { name: 'Bob' });
       expect(result).toBe('Bob:30');
     });
 
@@ -690,7 +678,7 @@ describe('dependency injection', () => {
 
     it('annotate returns dep names from an array-style invokable', () => {
       const injector = createInjector([]);
-      const deps = injector.annotate(['a', 'b', 'c', (a, b , c) => [a, b, c]]);
+      const deps = injector.annotate(['a', 'b', 'c', (a, b, c) => [a, b, c]]);
       expect(deps).toEqual(['a', 'b', 'c']);
     });
 

--- a/src/di/annotate.ts
+++ b/src/di/annotate.ts
@@ -1,0 +1,62 @@
+/**
+ * Standalone `annotate` helper for the Dependency Injection module.
+ *
+ * Slice 4 scope: extracts the dependency-name list from an {@link Invokable}
+ * by inspecting either its array-style annotation or its `$inject` property.
+ * Function-parameter inference (parsing `fn.toString()`) is intentionally NOT
+ * supported -- consumers must use one of the two explicit forms. The injector
+ * method {@link Injector.annotate} will delegate to this helper in Slice 5.
+ */
+
+import { isArray, isFunction } from '@core/utils';
+
+import type { Annotated, Invokable, InvokableArray } from './di-types';
+
+/**
+ * Extract the dependency name list from an {@link Invokable}.
+ *
+ * Supports two annotation styles:
+ *
+ * 1. **Array-style:** `['dep1', 'dep2', fn]` -- the dependency names are
+ *    everything in the tuple except the last element (the function itself).
+ * 2. **`$inject` property:** A function with `fn.$inject = ['dep1', 'dep2']`.
+ *
+ * Function-parameter inference (parsing `fn.toString()` to read parameter
+ * names) is intentionally NOT supported -- callers must use one of the two
+ * explicit forms above. This keeps the annotation contract robust under
+ * minification, which would otherwise rename parameters and silently break
+ * dependency resolution.
+ *
+ * @param fn - The invokable to inspect.
+ * @returns A readonly array of dependency names in declaration order.
+ * @throws {Error} when `fn` is a plain function without a `$inject` property.
+ * @throws {Error} when `fn` is neither an array nor a function.
+ */
+export function annotate(fn: Invokable): readonly string[] {
+  if (isArray(fn)) {
+    // Array-style annotation: ['dep1', 'dep2', fn]. The `InvokableArray` type
+    // guarantees the trailing element is the function, so everything before
+    // it is a dependency-name string. `slice(0, -1)` drops the function and
+    // yields the dependency list as a fresh array.
+    const tuple: InvokableArray = fn;
+    return tuple.slice(0, -1) as readonly string[];
+  }
+
+  if (isFunction(fn)) {
+    // Property-based annotation: `fn.$inject = ['dep1', 'dep2']`. We must
+    // narrow through `Annotated` because `isFunction` returns the broad
+    // `Function` type, which has no `$inject` property.
+    const annotated = fn as Annotated<(...args: never[]) => unknown>;
+    if (annotated.$inject !== undefined) {
+      return annotated.$inject;
+    }
+    throw new Error(
+      'Function has no $inject annotation. Use the array-style annotation ' +
+        "(['dep1', 'dep2', fn]) or attach a $inject property to the function.",
+    );
+  }
+
+  throw new Error(
+    'Invalid invokable: expected a function with $inject or an array-style ' + 'annotation [...deps, fn].',
+  );
+}

--- a/src/di/di-types.ts
+++ b/src/di/di-types.ts
@@ -1,0 +1,112 @@
+/**
+ * Core type definitions for the Dependency Injection module.
+ *
+ * The DI system uses a builder pattern where each registration call on a
+ * {@link ModuleAPI} returns a new `ModuleAPI` whose `Registry` type parameter
+ * has been extended with the newly-registered entry. The {@link Injector} is
+ * generic over the merged registry so that `injector.get('name')` can infer
+ * the return type from the string-literal name via indexed access.
+ */
+
+/**
+ * A function that may optionally carry an `$inject` annotation listing the
+ * names of its dependencies. This mirrors AngularJS's property-based inline
+ * annotation style: `fn.$inject = ['dep1', 'dep2']`.
+ */
+export type Annotated<Fn extends (...args: never[]) => unknown> = Fn & {
+  $inject?: readonly string[];
+};
+
+/**
+ * Array-style dependency annotation: a tuple whose leading entries are
+ * dependency names and whose final entry is the function to invoke.
+ *
+ * Example: `['dep1', 'dep2', (dep1, dep2) => { ... }]`.
+ */
+export type InvokableArray = readonly [...string[], (...deps: never[]) => unknown];
+
+/**
+ * Anything that can be invoked by the injector: either an annotated function
+ * (with an optional `$inject` property) or an array-style annotation.
+ */
+export type Invokable = Annotated<(...args: never[]) => unknown> | InvokableArray;
+
+/**
+ * The module builder interface, generic over an accumulated registry of
+ * registered service names to their types. Each registration method returns
+ * a new `ModuleAPI` whose registry type has been extended with the new entry,
+ * enabling precise type inference on downstream `injector.get(name)` calls.
+ */
+export interface ModuleAPI<
+  Registry extends Record<string, unknown> = Record<string, never>,
+  Name extends string = string,
+  Requires extends readonly string[] = readonly string[],
+> {
+  /** The unique name of this module. */
+  readonly name: Name;
+
+  /** Names of other modules this module depends on. */
+  readonly requires: Requires;
+
+  /**
+   * Register a plain value under `name`. Values are not invoked; they are
+   * returned as-is from the injector.
+   */
+  value<K extends string, T>(name: K, value: T): ModuleAPI<Registry & { [P in K]: T }, Name, Requires>;
+
+  /**
+   * Register a constant under `name`. Constants are available during the
+   * module configuration phase and are never overridden by decorators.
+   */
+  constant<K extends string, T>(name: K, value: T): ModuleAPI<Registry & { [P in K]: T }, Name, Requires>;
+
+  /**
+   * Register a factory under `name`. The factory is invoked lazily by the
+   * injector with its declared dependencies, and its return value is cached
+   * as the resolved service instance.
+   *
+   * `T` appears only in the return position because the factory's return
+   * type cannot yet be statically inferred from an `Invokable` -- callers
+   * supply it explicitly so downstream `injector.get(name)` lookups resolve
+   * to the correct type.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-parameters -- explicit caller-provided return type for registry inference
+  factory<K extends string, T>(name: K, factory: Invokable): ModuleAPI<Registry & { [P in K]: T }, Name, Requires>;
+}
+
+/**
+ * The injector interface, generic over the merged registry produced by the
+ * modules it was bootstrapped from.
+ *
+ * `get` is overloaded: when called with a key that is statically known to be
+ * in the registry, the return type is inferred from the registry entry.
+ * Otherwise, callers may provide an explicit type parameter as an escape
+ * hatch for dynamic lookups.
+ */
+export interface Injector<Registry extends Record<string, unknown> = Record<string, unknown>> {
+  /** Retrieve a registered service by its statically-known name. */
+  get<K extends keyof Registry>(name: K): Registry[K];
+
+  /**
+   * Retrieve a registered service by a dynamic name, with an explicit type.
+   * This is the escape-hatch overload for lookups where the name is not a
+   * statically-known key of `Registry`.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-parameters -- caller-provided type for dynamic-name escape hatch
+  get<T>(name: string): T;
+
+  /** Check whether a service with the given name is registered. */
+  has(name: string): boolean;
+
+  /**
+   * Invoke an {@link Invokable} with its dependencies resolved from the
+   * injector. An optional `self` binds `this`, and `locals` override specific
+   * dependency names for this call. `T` is a caller-provided hint for the
+   * invoked function's return type.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-parameters -- caller-provided return type hint
+  invoke<T = unknown>(fn: Invokable, self?: unknown, locals?: Record<string, unknown>): T;
+
+  /** Return the list of dependency names declared by an {@link Invokable}. */
+  annotate(fn: Invokable): readonly string[];
+}

--- a/src/di/di-types.ts
+++ b/src/di/di-types.ts
@@ -41,13 +41,28 @@ export type InvokableArray<Return = unknown> = readonly [...string[], (...deps: 
 export type Invokable<Return = unknown> = Annotated<(...args: never[]) => Return> | InvokableArray<Return>;
 
 /**
+ * Given a `Registry` and a tuple of dependency names, produce a tuple of the
+ * corresponding service types. Used by `Module.factory` to type a factory
+ * callback's parameters based on what the registry has registered.
+ *
+ * If a dependency name is not a key of `Registry` (for example, a name that
+ * comes from a transitively-required module), the slot resolves to `unknown`,
+ * which keeps the overload matchable while preserving type safety at call sites
+ * where every dep is statically known.
+ */
+export type ResolveDeps<Registry extends Record<string, unknown>, Deps extends readonly string[]> = {
+  [I in keyof Deps]: Deps[I] extends keyof Registry ? Registry[Deps[I]] : unknown;
+};
+
+/**
  * The module builder interface, generic over an accumulated registry of
  * registered service names to their types. Each registration method returns
  * a new `ModuleAPI` whose registry type has been extended with the new entry,
  * enabling precise type inference on downstream `injector.get(name)` calls.
  */
 export interface ModuleAPI<
-  Registry extends Record<string, unknown> = Record<string, never>,
+  // eslint-disable-next-line @typescript-eslint/no-empty-object-type -- see note on `Module` in module.ts: `{}` (not `Record<string, never>`) is the correct empty-registry starting type so that newly-added literal keys aren't swallowed by a wide `string` index signature, which would break the typed-factory overloads.
+  Registry extends Record<string, unknown> = {},
   Name extends string = string,
   Requires extends readonly string[] = readonly string[],
 > {
@@ -70,18 +85,50 @@ export interface ModuleAPI<
   constant<K extends string, T>(name: K, value: T): ModuleAPI<Registry & { [P in K]: T }, Name, Requires>;
 
   /**
-   * Register a factory under `name`. The factory is invoked lazily by the
-   * injector with its declared dependencies, and its return value is cached
-   * as the resolved service instance.
+   * Register a factory under `name` using an array-style annotation whose
+   * leading entries are keys of the current `Registry`. The trailing
+   * function's parameters are inferred from {@link ResolveDeps}, giving each
+   * dep argument the exact type recorded by an earlier `value` / `constant` /
+   * `factory` registration on this module.
    *
-   * `Return` is inferred from the trailing function of the supplied
-   * {@link Invokable}, so downstream `injector.get(name)` lookups resolve to
-   * the factory's actual return type without any explicit annotation. Callers
-   * may still supply `Return` explicitly as an escape hatch.
+   * **Typo detection limitation.** When a dep name does not exist on the
+   * module's `Registry` (e.g. because it's a typo, or because it comes from
+   * a transitively-required module), this typed overload silently fails to
+   * match and the call site falls through to the untyped fallback below.
+   * TypeScript's overload resolution is "first success wins," so the
+   * constraint error on this overload does not surface. Callback param
+   * inference still fires for valid dep lists; detecting typos via the type
+   * system would require a different, more invasive design and is out of
+   * scope here.
+   */
+  factory<const K extends string, const Deps extends readonly (keyof Registry & string)[], Return>(
+    name: K,
+    invokable: readonly [...Deps, (...args: ResolveDeps<Registry, Deps>) => Return],
+  ): ModuleAPI<Registry & { [P in K]: Return }, Name, Requires>;
+
+  /**
+   * Register a factory under `name` using a `$inject`-annotated function whose
+   * `$inject` property is a readonly literal tuple of keys of `Registry`. The
+   * function's parameter types are validated against {@link ResolveDeps}.
+   * Annotate `$inject` with `as const` (or a `readonly` tuple type) so the
+   * compiler can see the literal dep names.
+   */
+  factory<const K extends string, const Inject extends readonly (keyof Registry & string)[], Return>(
+    name: K,
+    invokable: ((...args: ResolveDeps<Registry, Inject>) => Return) & { $inject: Inject },
+  ): ModuleAPI<Registry & { [P in K]: Return }, Name, Requires>;
+
+  /**
+   * Fallback overload for factories whose dependencies cannot be validated at
+   * compile time against the current `Registry` — for example, factories that
+   * reference services from a transitively-required module, or those whose
+   * `$inject` property is typed as the wider `string[]`. Behaves exactly like
+   * the old untyped signature: `Return` is still inferred from the trailing
+   * function, but the callback's parameters are not typed from the registry.
    */
   factory<K extends string, Return>(
     name: K,
-    factory: Invokable<Return>,
+    invokable: Invokable<Return>,
   ): ModuleAPI<Registry & { [P in K]: Return }, Name, Requires>;
 }
 

--- a/src/di/di-types.ts
+++ b/src/di/di-types.ts
@@ -157,11 +157,45 @@ export interface Injector<Registry extends Record<string, unknown> = Record<stri
   has(name: string): boolean;
 
   /**
-   * Invoke an {@link Invokable} with its dependencies resolved from the
-   * injector. An optional `self` binds `this`, and `locals` override specific
-   * dependency names for this call. `Return` is inferred from the supplied
-   * invokable's trailing function -- callers don't need to annotate it unless
-   * they want to widen or narrow the inferred type explicitly.
+   * Array-style invoke with deps validated against `Registry`. Each leading
+   * entry must be a literal key of this injector's registry, and the trailing
+   * callback's parameters are inferred from {@link ResolveDeps} — so each
+   * callback argument is typed from the earlier `value` / `constant` /
+   * `factory` registration that populated the registry.
+   *
+   * **Typo / cross-registry limitation.** When a dep name does not exist on
+   * the injector's `Registry` (for example, a typo or a service registered on
+   * a transitively-required module that isn't reflected in `Mods`), this
+   * overload silently fails to match and call sites fall through to the
+   * untyped fallback below. TypeScript's overload resolution is "first
+   * success wins," so the constraint error on this overload does not surface.
+   * Typed param inference still works for valid dep lists.
+   */
+  invoke<const Deps extends readonly (keyof Registry & string)[], Return>(
+    fn: readonly [...Deps, (...args: ResolveDeps<Registry, Deps>) => Return],
+    self?: unknown,
+    locals?: Record<string, unknown>,
+  ): Return;
+
+  /**
+   * `$inject`-annotated invoke with deps validated against `Registry`. The
+   * function's `$inject` property must be a `readonly` literal tuple whose
+   * entries are keys of `Registry`; the function's parameters are validated
+   * against {@link ResolveDeps}. Annotate `$inject` with `as const` (or a
+   * readonly tuple type) so the compiler can see the literal dep names.
+   */
+  invoke<const Inject extends readonly (keyof Registry & string)[], Return>(
+    fn: ((...args: ResolveDeps<Registry, Inject>) => Return) & { $inject: Inject },
+    self?: unknown,
+    locals?: Record<string, unknown>,
+  ): Return;
+
+  /**
+   * Fallback untyped overload — used when deps can't be validated statically
+   * (e.g. cross-module deps from a `requires` dependency, wide `string[]`
+   * `$inject` properties, or pre-built `Invokable<Return>` values passed as
+   * opaque variables). `Return` is still inferred from the trailing function
+   * so callers don't need to annotate it explicitly.
    */
   invoke<Return>(fn: Invokable<Return>, self?: unknown, locals?: Record<string, unknown>): Return;
 

--- a/src/di/di-types.ts
+++ b/src/di/di-types.ts
@@ -21,15 +21,24 @@ export type Annotated<Fn extends (...args: never[]) => unknown> = Fn & {
  * Array-style dependency annotation: a tuple whose leading entries are
  * dependency names and whose final entry is the function to invoke.
  *
+ * Generic over `Return` so callers get the trailing function's return type
+ * inferred automatically -- no explicit annotation required at call sites of
+ * `Module.factory` or `Injector.invoke`.
+ *
  * Example: `['dep1', 'dep2', (dep1, dep2) => { ... }]`.
  */
-export type InvokableArray = readonly [...string[], (...deps: never[]) => unknown];
+export type InvokableArray<Return = unknown> = readonly [...string[], (...deps: never[]) => Return];
 
 /**
  * Anything that can be invoked by the injector: either an annotated function
  * (with an optional `$inject` property) or an array-style annotation.
+ *
+ * Generic over `Return` so callers get return-type inference on
+ * `Module.factory` and `Injector.invoke`. The default `Return = unknown`
+ * keeps `Invokable` usable as an opaque "any invokable" type in spots like
+ * the `annotate` helper or the injector's internal factory cache.
  */
-export type Invokable = Annotated<(...args: never[]) => unknown> | InvokableArray;
+export type Invokable<Return = unknown> = Annotated<(...args: never[]) => Return> | InvokableArray<Return>;
 
 /**
  * The module builder interface, generic over an accumulated registry of
@@ -65,13 +74,15 @@ export interface ModuleAPI<
    * injector with its declared dependencies, and its return value is cached
    * as the resolved service instance.
    *
-   * `T` appears only in the return position because the factory's return
-   * type cannot yet be statically inferred from an `Invokable` -- callers
-   * supply it explicitly so downstream `injector.get(name)` lookups resolve
-   * to the correct type.
+   * `Return` is inferred from the trailing function of the supplied
+   * {@link Invokable}, so downstream `injector.get(name)` lookups resolve to
+   * the factory's actual return type without any explicit annotation. Callers
+   * may still supply `Return` explicitly as an escape hatch.
    */
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-parameters -- explicit caller-provided return type for registry inference
-  factory<K extends string, T>(name: K, factory: Invokable): ModuleAPI<Registry & { [P in K]: T }, Name, Requires>;
+  factory<K extends string, Return>(
+    name: K,
+    factory: Invokable<Return>,
+  ): ModuleAPI<Registry & { [P in K]: Return }, Name, Requires>;
 }
 
 /**
@@ -101,11 +112,11 @@ export interface Injector<Registry extends Record<string, unknown> = Record<stri
   /**
    * Invoke an {@link Invokable} with its dependencies resolved from the
    * injector. An optional `self` binds `this`, and `locals` override specific
-   * dependency names for this call. `T` is a caller-provided hint for the
-   * invoked function's return type.
+   * dependency names for this call. `Return` is inferred from the supplied
+   * invokable's trailing function -- callers don't need to annotate it unless
+   * they want to widen or narrow the inferred type explicitly.
    */
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-parameters -- caller-provided return type hint
-  invoke<T = unknown>(fn: Invokable, self?: unknown, locals?: Record<string, unknown>): T;
+  invoke<Return>(fn: Invokable<Return>, self?: unknown, locals?: Record<string, unknown>): Return;
 
   /** Return the list of dependency names declared by an {@link Invokable}. */
   annotate(fn: Invokable): readonly string[];

--- a/src/di/index.ts
+++ b/src/di/index.ts
@@ -1,5 +1,5 @@
 export { Module, createModule, getModule, resetRegistry } from './module';
-export type { AnyModule, InvokeQueueEntry, RecipeType } from './module';
+export type { AnyModule, InvokeQueueEntry, RecipeType, TypedModule } from './module';
 export { createInjector } from './injector';
 export type { MergeRegistries } from './injector';
-export type { Annotated, Injector, Invokable, InvokableArray, ModuleAPI } from './di-types';
+export type { Annotated, Injector, Invokable, InvokableArray, ModuleAPI, ResolveDeps } from './di-types';

--- a/src/di/index.ts
+++ b/src/di/index.ts
@@ -1,3 +1,5 @@
 export { Module, createModule, getModule, resetRegistry } from './module';
-export type { InvokeQueueEntry, RecipeType } from './module';
+export type { AnyModule, InvokeQueueEntry, RecipeType } from './module';
+export { createInjector } from './injector';
+export type { MergeRegistries } from './injector';
 export type { Annotated, Injector, Invokable, InvokableArray, ModuleAPI } from './di-types';

--- a/src/di/index.ts
+++ b/src/di/index.ts
@@ -1,1 +1,3 @@
-export {};
+export { Module, createModule, getModule, resetRegistry } from './module';
+export type { InvokeQueueEntry, RecipeType } from './module';
+export type { Annotated, Injector, Invokable, InvokableArray, ModuleAPI } from './di-types';

--- a/src/di/injector.ts
+++ b/src/di/injector.ts
@@ -110,6 +110,13 @@ export function createInjector<const Mods extends readonly AnyModule[]>(
   const providerCache = new Map<string, unknown>();
   const factoryInvokables = new Map<string, Invokable>();
   const loadedModules = new Set<string>();
+  // Stack of names currently being resolved by `get`. When a factory
+  // (transitively) requests a name already on the stack we have a service-
+  // level circular dependency; we surface the full chain in the error
+  // message so callers can see exactly which services form the cycle. The
+  // stack is push/pop-balanced via `try/finally` so a thrown dependency
+  // does not leak stale entries into later lookups.
+  const resolutionPath: string[] = [];
 
   /**
    * Recursively load `mod` and everything it transitively requires. The
@@ -158,6 +165,18 @@ export function createInjector<const Mods extends readonly AnyModule[]>(
       return providerCache.get(name) as T;
     }
     if (factoryInvokables.has(name)) {
+      // Circular dependency detection: if `name` is already on the resolution
+      // stack, a factory higher up the call chain (transitively) asked for a
+      // service that is still pending. Build a right-to-left chain of the
+      // pending names followed by `name` itself so the error shows the full
+      // cycle (e.g. `A <- B <- A`). The chain reads "A is waiting on B, which
+      // is waiting on A" -- the `<-` arrows point from the waiter to what it
+      // is waiting on.
+      if (resolutionPath.includes(name)) {
+        const chain = [...resolutionPath, name].join(' <- ');
+        throw new Error(`Circular dependency: ${chain}`);
+      }
+
       const invokable = factoryInvokables.get(name);
       if (invokable === undefined) {
         // Defensive: `Map.has` just said yes, so this branch is only reachable
@@ -165,19 +184,25 @@ export function createInjector<const Mods extends readonly AnyModule[]>(
         // same as an unregistered provider rather than silently returning.
         throw new Error(`Unknown provider: ${name}`);
       }
-      // Delete before invoking so that if the factory (transitively) requests
-      // itself during its own initialization we surface an "Unknown provider"
-      // error instead of silently re-entering and stack-overflowing. Proper
-      // cycle detection with a clear error message lands in Slice 6.
-      factoryInvokables.delete(name);
-      const deps = annotateInvokable(invokable);
-      const resolvedDeps = deps.map((depName) => get(depName));
-      const fn = isArray(invokable)
-        ? (invokable[invokable.length - 1] as (...args: unknown[]) => unknown)
-        : (invokable as unknown as (...args: unknown[]) => unknown);
-      const result = fn(...resolvedDeps);
-      providerCache.set(name, result);
-      return result as T;
+
+      resolutionPath.push(name);
+      try {
+        const deps = annotateInvokable(invokable);
+        const resolvedDeps = deps.map((depName) => get(depName));
+        const fn = isArray(invokable)
+          ? (invokable[invokable.length - 1] as (...args: unknown[]) => unknown)
+          : (invokable as unknown as (...args: unknown[]) => unknown);
+        const result = fn(...resolvedDeps);
+        providerCache.set(name, result);
+        // Now that the result is cached, the invokable is no longer pending
+        // and can be dropped from the factory map. Deleting *after* caching
+        // (rather than before resolving) is what lets the `resolutionPath`
+        // check above see the entry on re-entry and report a proper cycle.
+        factoryInvokables.delete(name);
+        return result as T;
+      } finally {
+        resolutionPath.pop();
+      }
     }
     throw new Error(`Unknown provider: ${name}`);
   }

--- a/src/di/injector.ts
+++ b/src/di/injector.ts
@@ -1,0 +1,219 @@
+/**
+ * Injector factory for the Dependency Injection module.
+ *
+ * Slice 4 scope: supports `value`, `constant`, and `factory` recipes, and
+ * walks the module dependency graph. `createInjector` recursively loads
+ * each module's `requires` from the module registry before draining its
+ * own `invokeQueue`, tracking loaded module names in a `Set<string>` so
+ * that shared, diamond, and circular module-level dependencies are each
+ * loaded at most once. Factory entries are stored as unresolved invokables
+ * at load time and invoked lazily on the first `get(name)` call, with
+ * their results cached as singletons. `invoke`/`annotate` remain stubs
+ * until Slice 5.
+ */
+
+import { isArray } from '@core/utils';
+
+import { annotate as annotateInvokable } from './annotate';
+import type { Injector, Invokable } from './di-types';
+import { getModule, type AnyModule, type Module } from './module';
+
+/**
+ * Extract the `Registry` type parameter from a concrete {@link Module} type.
+ * Resolves to `never` when the input is not a `Module`, which makes it a
+ * safe building block inside a distributive conditional type.
+ */
+type ExtractRegistry<M> = M extends Module<infer R> ? R : never;
+
+/**
+ * Convert a union type `U` into the intersection of all its members.
+ *
+ * Implementation note: wrapping `U` in a contravariant position
+ * (`(x: U) => void`) and then inferring back out of that position forces
+ * TypeScript to collapse the distributed union into a single intersection.
+ * This is the standard trick for union-to-intersection conversion and is the
+ * only way to combine an unknown number of module registries at the type
+ * level without recursive conditional types.
+ */
+type UnionToIntersection<U> = (U extends unknown ? (x: U) => void : never) extends (x: infer I) => void ? I : never;
+
+/**
+ * Given a tuple of {@link Module} instances, produce an intersection of all
+ * their `Registry` type parameters.
+ *
+ * Used by {@link createInjector} to build a single typed registry from
+ * multiple input modules so that `injector.get(name)` is typed against the
+ * union of every registered service across all input modules.
+ *
+ * The result is constrained to `Record<string, unknown>` so it satisfies the
+ * shape expected by the {@link Injector} interface even in the edge case of
+ * an empty `Mods` tuple (where the intersection collapses to `unknown`).
+ */
+export type MergeRegistries<Mods extends readonly AnyModule[]> =
+  UnionToIntersection<ExtractRegistry<Mods[number]>> extends infer R
+    ? R extends Record<string, unknown>
+      ? R
+      : Record<string, never>
+    : Record<string, never>;
+
+/**
+ * Build a typed {@link Injector} from a tuple of module instances.
+ *
+ * Slice 3 behavior: for every input module, the injector performs a
+ * post-order walk of the module dependency graph. Each module in
+ * `module.requires` is looked up in the module registry via {@link getModule}
+ * and loaded recursively before the enclosing module's own `invokeQueue` is
+ * drained. A `Set<string>` of already-loaded module names guards the walk so
+ * that:
+ *
+ * - **Shared dependencies** (two modules depending on the same third) load
+ *   the shared module exactly once.
+ * - **Diamond dependencies** (A -> {B, C} -> D) load `D` exactly once.
+ * - **Circular module-level dependencies** (A -> B -> A) terminate on the
+ *   second visit instead of recursing forever.
+ *
+ * Dependencies are loaded before their dependents so that when `factory`
+ * entries begin resolving their own dependencies in Slice 4, every name they
+ * reference is already registered in the provider cache.
+ *
+ * The return type `Injector<MergeRegistries<Mods>>` lets TypeScript infer
+ * the registered service types from the input module tuple, so
+ * `injector.get('apiUrl')` resolves to the exact type recorded by the
+ * corresponding `module.value('apiUrl', ...)` call at compile time. A
+ * fallback `get<T>(name: string): T` overload on the {@link Injector}
+ * interface provides an escape hatch for dynamic-name lookups.
+ *
+ * **Compile-time vs. runtime dependency tracking.** At runtime the injector
+ * auto-walks `requires`, so callers only need to pass the root module(s) they
+ * care about. At compile time, however, `MergeRegistries<Mods>` only sees the
+ * modules that were passed explicitly -- transitively-loaded modules are not
+ * reflected in the resulting `Injector`'s static registry. Lookups for names
+ * registered on a transitive module therefore fall through to the dynamic
+ * `get<T>(name: string): T` escape hatch and must supply their own type
+ * argument. Tightening this to full compile-time transitive tracking is a
+ * future concern; it is deliberately out of scope for Slice 3.
+ *
+ * @param modules - Tuple of module instances whose registrations should be
+ *   drained into the returned injector. Any modules referenced transitively
+ *   through `requires` are resolved automatically via the module registry.
+ * @throws {Error} with message `Module not found: <name>` when a `requires`
+ *   entry references a module that is not present in the registry.
+ */
+export function createInjector<const Mods extends readonly AnyModule[]>(
+  modules: Mods,
+): Injector<MergeRegistries<Mods>> {
+  const providerCache = new Map<string, unknown>();
+  const factoryInvokables = new Map<string, Invokable>();
+  const loadedModules = new Set<string>();
+
+  /**
+   * Recursively load `mod` and everything it transitively requires. The
+   * traversal is post-order: dependencies are drained into `providerCache`
+   * before the enclosing module's own queue, which matches AngularJS's
+   * behavior and ensures that Slice 4 factories will find their dependencies
+   * already resolved. The `loadedModules` set makes the walk idempotent on a
+   * per-module-name basis, which also breaks any cycles at the module graph
+   * level.
+   */
+  function loadModule(mod: AnyModule): void {
+    if (loadedModules.has(mod.name)) {
+      return;
+    }
+    loadedModules.add(mod.name);
+
+    for (const requiredName of mod.requires) {
+      // `getModule` throws `Module not found: <name>` when the registry has
+      // no entry, which is exactly the error contract this function wants to
+      // propagate, so we deliberately let it bubble up unchanged.
+      const required = getModule(requiredName);
+      loadModule(required);
+    }
+
+    for (const [recipe, name, value] of mod.invokeQueue) {
+      if (recipe === 'value' || recipe === 'constant') {
+        providerCache.set(name, value);
+      } else {
+        // `recipe` narrows to `'factory'` here -- it is the only remaining
+        // member of `RecipeType`. Factories are lazy: stash the invokable
+        // now and invoke it on the first `get(name)` call. The invoke-queue
+        // entry's `value` slot holds the raw `Invokable` passed to
+        // `module.factory(name, invokable)`.
+        factoryInvokables.set(name, value as Invokable);
+      }
+    }
+  }
+
+  for (const module of modules) {
+    loadModule(module);
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-parameters -- caller-provided type for dynamic-name escape hatch; the typed `Injector.get` overload relies on this signature.
+  function get<T>(name: string): T {
+    if (providerCache.has(name)) {
+      return providerCache.get(name) as T;
+    }
+    if (factoryInvokables.has(name)) {
+      const invokable = factoryInvokables.get(name);
+      if (invokable === undefined) {
+        // Defensive: `Map.has` just said yes, so this branch is only reachable
+        // if an `undefined` was somehow stored under `name`. Treat it the
+        // same as an unregistered provider rather than silently returning.
+        throw new Error(`Unknown provider: ${name}`);
+      }
+      // Delete before invoking so that if the factory (transitively) requests
+      // itself during its own initialization we surface an "Unknown provider"
+      // error instead of silently re-entering and stack-overflowing. Proper
+      // cycle detection with a clear error message lands in Slice 6.
+      factoryInvokables.delete(name);
+      const deps = annotateInvokable(invokable);
+      const resolvedDeps = deps.map((depName) => get(depName));
+      const fn = isArray(invokable)
+        ? (invokable[invokable.length - 1] as (...args: unknown[]) => unknown)
+        : (invokable as unknown as (...args: unknown[]) => unknown);
+      const result = fn(...resolvedDeps);
+      providerCache.set(name, result);
+      return result as T;
+    }
+    throw new Error(`Unknown provider: ${name}`);
+  }
+
+  function has(name: string) {
+    return providerCache.has(name) || factoryInvokables.has(name);
+  }
+
+  function invoke<Return>(fn: Invokable<Return>, self?: unknown, locals?: Record<string, unknown>): Return {
+    const deps = annotateInvokable(fn);
+    const resolvedDeps = deps.map((depName) => {
+      // `hasOwnProperty.call` rather than `locals[depName] !== undefined` so
+      // that callers can explicitly pass `undefined` as an override value
+      // without it silently falling through to the injector lookup.
+      if (locals !== undefined && Object.prototype.hasOwnProperty.call(locals, depName)) {
+        return locals[depName];
+      }
+      return get(depName);
+    });
+
+    const actualFn = isArray(fn)
+      ? (fn[fn.length - 1] as (...args: unknown[]) => unknown)
+      : (fn as unknown as (...args: unknown[]) => unknown);
+
+    return actualFn.apply(self, resolvedDeps) as Return;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars -- stub implementation, full version lands in Slice 5
+  function annotate(fn: Invokable): readonly string[] {
+    throw new Error('injector.annotate is not yet implemented');
+  }
+
+  // The `get` local is typed as the dynamic-name overload `<T>(name: string) => T`.
+  // The public `Injector<Registry>` interface exposes a second, registry-keyed
+  // overload that narrows the return type at call sites. Both overloads share
+  // the same runtime implementation, so we widen through `unknown` here rather
+  // than duplicating the overload signatures on the local function expression.
+  return {
+    get,
+    has,
+    invoke,
+    annotate,
+  };
+}

--- a/src/di/injector.ts
+++ b/src/di/injector.ts
@@ -16,14 +16,19 @@ import { isArray } from '@core/utils';
 
 import { annotate as annotateInvokable } from './annotate';
 import type { Injector, Invokable } from './di-types';
-import { getModule, type AnyModule, type Module } from './module';
+import { getModule, type AnyModule, type Module, type TypedModule } from './module';
 
 /**
- * Extract the `Registry` type parameter from a concrete {@link Module} type.
- * Resolves to `never` when the input is not a `Module`, which makes it a
- * safe building block inside a distributive conditional type.
+ * Extract the `Registry` type parameter from a concrete {@link Module} or
+ * {@link TypedModule} type. The `TypedModule` branch is tried first because
+ * `createModule` returns that typed view; `TypedModule<R, ...>` structurally
+ * also extends `Module<R, ...>`, but the extra factory overloads on
+ * `TypedModule` can confuse single-pattern inference in some cases, so we
+ * match it explicitly. Resolves to `never` when the input is neither, which
+ * keeps it safe inside a distributive conditional type.
  */
-type ExtractRegistry<M> = M extends Module<infer R> ? R : never;
+type ExtractRegistry<M> =
+  M extends TypedModule<infer R, string, readonly string[]> ? R : M extends Module<infer R> ? R : never;
 
 /**
  * Convert a union type `U` into the intersection of all its members.
@@ -200,9 +205,14 @@ export function createInjector<const Mods extends readonly AnyModule[]>(
     return actualFn.apply(self, resolvedDeps) as Return;
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars -- stub implementation, full version lands in Slice 5
+  /**
+   * Delegate to the shared `annotate` helper to extract the dependency name
+   * list from an {@link Invokable}. Exposed on the injector so that consumers
+   * (e.g. test harnesses, higher-level APIs) can inspect an invokable's
+   * declared dependencies without importing the helper directly.
+   */
   function annotate(fn: Invokable): readonly string[] {
-    throw new Error('injector.annotate is not yet implemented');
+    return annotateInvokable(fn);
   }
 
   // The `get` local is typed as the dynamic-name overload `<T>(name: string) => T`.

--- a/src/di/module.ts
+++ b/src/di/module.ts
@@ -1,0 +1,175 @@
+/**
+ * Recipe types supported by the module system. At Slice 1 only the identifier
+ * strings are needed -- the actual `value`, `constant`, and `factory` methods
+ * will be added to the `Module` class in later slices.
+ */
+export type RecipeType = 'value' | 'constant' | 'factory';
+
+/**
+ * A single pending registration in a module's invoke queue. The tuple is
+ * `[recipeType, name, value]` where `value` is the raw argument passed to the
+ * registration method (a plain value for `value`/`constant`, or an
+ * {@link Invokable} for `factory`). The queue is drained by the injector when
+ * it is created from the module graph.
+ */
+export type InvokeQueueEntry = readonly [RecipeType, string, unknown];
+
+/**
+ * The most-general `Module` type, used by the internal registry which must
+ * hold modules of any concrete `Registry` / `Name` / `Requires` shape.
+ */
+export type AnyModule = Module<Record<string, unknown>>;
+
+/**
+ * Module-scoped registry of all modules created via {@link createModule}.
+ * Keyed by module name. Kept private to this file -- both `createModule` and
+ * `getModule` go through this registry so there is a single source of truth.
+ */
+const registry = new Map<string, AnyModule>();
+
+/**
+ * A declarative module: a named collection of pending service registrations
+ * plus a list of module dependencies.
+ *
+ * The class is generic over three type parameters:
+ *
+ * - `Registry` -- a mapped type carrying the accumulated static registry of
+ *   registered service names to their types. Each registration method
+ *   (`value`, `constant`) returns `this` cast to a widened
+ *   `Module<Registry & { [K in Name]: T }, Name, Requires>` so the builder
+ *   pattern can accumulate precise static types for downstream injector
+ *   lookups while keeping a single runtime instance.
+ * - `Name` -- the string-literal type of this module's own name, preserved
+ *   so that callers can statically track identity across the builder chain
+ *   and so `createInjector` can reject references to unknown modules at
+ *   compile time.
+ * - `Requires` -- the readonly-tuple type of this module's declared
+ *   dependencies, preserved for the same reason.
+ */
+
+export class Module<
+  Registry extends Record<string, unknown> = Record<string, never>,
+  Name extends string = string,
+  Requires extends readonly string[] = readonly string[],
+> {
+  /** The unique name of this module within the module registry. */
+  readonly name: Name;
+
+  /** Names of other modules this module depends on. */
+  readonly requires: Requires;
+
+  /**
+   * Queue of pending registrations accumulated by calls to `value`, `constant`,
+   * and `factory`. The injector drains this queue during its load phase.
+   */
+  readonly invokeQueue: InvokeQueueEntry[];
+
+  constructor(name: Name, requires: Requires) {
+    this.name = name;
+    this.requires = requires;
+    this.invokeQueue = [];
+  }
+
+  /**
+   * Register a plain value under `name`. The registration is appended to
+   * {@link invokeQueue} as `['value', name, value]` and actually materialized
+   * when an injector drains the queue. Returns the same module instance with
+   * its `Registry` type widened to include the new entry.
+   *
+   * @param name - The name to register the value under.
+   * @param value - The value to associate with `name`.
+   */
+  value<K extends string, T>(name: K, value: T): Module<Registry & { [P in K]: T }, Name, Requires> {
+    this.invokeQueue.push(['value', name, value]);
+    return this as unknown as Module<Registry & { [P in K]: T }, Name, Requires>;
+  }
+
+  /**
+   * Register a constant under `name`. Constants are semantically identical to
+   * values for the module-loading phase; the injector distinguishes them at
+   * drain time. The registration is appended to {@link invokeQueue} as
+   * `['constant', name, value]`. Returns the same module instance with its
+   * `Registry` type widened to include the new entry.
+   *
+   * @param name - The name to register the constant under.
+   * @param value - The constant value to associate with `name`.
+   */
+  constant<K extends string, T>(name: K, value: T): Module<Registry & { [P in K]: T }, Name, Requires> {
+    this.invokeQueue.push(['constant', name, value]);
+    return this as unknown as Module<Registry & { [P in K]: T }, Name, Requires>;
+  }
+}
+
+/**
+ * Create a new {@link Module} and register it in the module-scoped registry.
+ *
+ * Creating a module with the same name as an existing module replaces the
+ * previous registration.
+ *
+ * The `const` modifier on the type parameters forces TypeScript to infer
+ * string-literal and tuple-literal types for `name` and `requires` instead of
+ * widening them to `string` / `readonly string[]`. This is what enables
+ * compile-time verification of the module dependency graph.
+ *
+ * @param name - Unique name for the module within the registry.
+ * @param requires - Names of other modules this module depends on. Defaults
+ *   to an empty array when no dependencies are required.
+ */
+export function createModule<const TName extends string, const TRequires extends readonly string[] = readonly []>(
+  name: TName,
+  requires: TRequires = [] as unknown as TRequires,
+): Module<Record<string, never>, TName, TRequires> {
+  const module = new Module<Record<string, never>, TName, TRequires>(name, requires);
+  registry.set(name, module as unknown as AnyModule);
+  return module;
+}
+
+/**
+ * Retrieve a previously-registered module by name.
+ *
+ * Because the registry is a runtime `Map<string, AnyModule>`, there is no way
+ * for TypeScript to automatically infer a specific module's typed shape from
+ * just a string lookup. Two usage modes are supported:
+ *
+ * **Dynamic (default):**
+ *
+ * ```ts
+ * const mod = getModule('app'); // typed as AnyModule
+ * ```
+ *
+ * **Typed via witness:** Supply an explicit type argument `M` — typically
+ * `typeof someKnownModule`. The `name` parameter is then constrained to that
+ * module's own `Name` literal, so typos become compile errors. The cast is
+ * checked by TypeScript against the registry entry at the call site, so it is
+ * safe as long as the witness type actually matches what was registered.
+ *
+ * ```ts
+ * const app = createModule('app', ['common']).value('apiUrl', 'https://...');
+ * // Later, from somewhere without direct access to `app`:
+ * const sameApp = getModule<typeof app>('app'); // fully typed
+ * const typo    = getModule<typeof app>('apx'); // compile error
+ * ```
+ *
+ * When a typed reference is already in scope, prefer using it directly instead
+ * of going through `getModule`.
+ *
+ * @param name - Name of the module to look up.
+ * @throws {Error} with message `Module not found: <name>` when no module with
+ *   the given name has been registered.
+ */
+export function getModule<M extends AnyModule = AnyModule>(name: M['name']): M {
+  const module = registry.get(name);
+  if (module === undefined) {
+    throw new Error(`Module not found: ${name}`);
+  }
+  return module as M;
+}
+
+/**
+ * Clear the module registry. Intended for use in test setup hooks
+ * (`beforeEach(() => resetRegistry())`) to guarantee isolation between tests
+ * that exercise the shared module registry.
+ */
+export function resetRegistry(): void {
+  registry.clear();
+}

--- a/src/di/module.ts
+++ b/src/di/module.ts
@@ -1,4 +1,4 @@
-import type { Invokable } from './di-types';
+import type { Invokable, ResolveDeps } from './di-types';
 
 /**
  * Recipe types supported by the module system. At Slice 1 only the identifier
@@ -50,7 +50,8 @@ const registry = new Map<string, AnyModule>();
  */
 
 export class Module<
-  Registry extends Record<string, unknown> = Record<string, never>,
+  // eslint-disable-next-line @typescript-eslint/no-empty-object-type -- `{}` (not `Record<string, never>`) is the correct "empty registry" starting type: its `keyof` is `never`, which lets the typed-factory overloads reject dep names against newly-added literal keys. `Record<string, never>` has a wide `string` index signature that swallows literal keys and breaks `Module` subtype variance between the class and `AnyModule`.
+  Registry extends Record<string, unknown> = {},
   Name extends string = string,
   Requires extends readonly string[] = readonly string[],
 > {
@@ -115,6 +116,13 @@ export class Module<
    * without any explicit annotation. Callers may still provide `Return`
    * explicitly (e.g. `.factory<'svc', MyShape>(...)`) as an escape hatch.
    *
+   * Note: the compile-time typed overloads that validate dep names against
+   * this module's `Registry` live on {@link TypedModule}, not on the class.
+   * `createModule` returns the same runtime instance cast to `TypedModule`,
+   * which is where callers get the typed `.factory(...)` experience. Keeping
+   * the class signature wide here preserves the covariance of `Module` in
+   * `Registry`, which `AnyModule` and `createInjector` rely on.
+   *
    * @param name - The name to register the factory under.
    * @param invokable - The factory, as an array-style annotation or an
    *   `$inject`-annotated function.
@@ -126,6 +134,90 @@ export class Module<
     this.invokeQueue.push(['factory', name, invokable]);
     return this as unknown as Module<Registry & { [P in K]: Return }, Name, Requires>;
   }
+}
+
+/**
+ * Typed builder view of a {@link Module}, returned by {@link createModule}.
+ *
+ * At runtime this is exactly the same object as the underlying `Module` class
+ * instance. At the type level it overlays three additional `factory` overloads
+ * that validate dependency names against this module's own `Registry`:
+ *
+ * 1. **Array-style with typed deps** — each leading entry is constrained to
+ *    `keyof Registry & string`, and the trailing callback's parameters are
+ *    inferred from {@link ResolveDeps}. When every dep is a registered
+ *    literal key, the callback arguments come back typed; when some dep is
+ *    unknown to the local registry, the overload falls through to #3 below
+ *    (see the typo-detection note on the overload itself).
+ * 2. **`$inject`-annotated with typed deps** — the function's `$inject`
+ *    property must be a `readonly` literal tuple of `keyof Registry & string`
+ *    entries. Users must annotate `$inject` with `as const` (or a readonly
+ *    tuple type) so TypeScript sees the literal dep names.
+ * 3. **Untyped fallback** — the original `Invokable<Return>` signature,
+ *    preserved for backward compatibility with factories that reference deps
+ *    from transitively-required modules, factories whose `$inject` is a wider
+ *    `string[]`, and existing call sites that explicitly annotate
+ *    `.factory<'name', Shape>(...)`.
+ *
+ * The typed overloads live on this interface rather than on the class itself
+ * because adding Registry-dependent parameter types to a class method puts
+ * `Registry` in a contravariant position on the method. That breaks the
+ * covariant subtype relationship `Module<A> <: Module<B>` when `A <: B`,
+ * which `AnyModule` and `createInjector` rely on. Keeping the typed overloads
+ * on `TypedModule` sidesteps the variance conflict: the interface extends the
+ * class instance side but never participates in the `AnyModule` widening
+ * check — the cast to `AnyModule` goes through the bare `Module` class.
+ */
+export interface TypedModule<
+  Registry extends Record<string, unknown>,
+  Name extends string,
+  Requires extends readonly string[],
+> extends Module<Registry, Name, Requires> {
+  value<const K extends string, T>(name: K, value: T): TypedModule<Registry & { [P in K]: T }, Name, Requires>;
+
+  constant<const K extends string, T>(name: K, value: T): TypedModule<Registry & { [P in K]: T }, Name, Requires>;
+
+  /**
+   * Array-style factory with deps validated against `Registry`. Each leading
+   * entry must be a literal key of the current `Registry`, and the trailing
+   * callback's parameters are inferred from {@link ResolveDeps} — so each
+   * callback argument is typed from the earlier `value` / `constant` /
+   * `factory` registration on this module.
+   *
+   * **Typo detection limitation.** When a dep name is a typo (or a name that
+   * lives on a transitively-required module), this overload silently fails
+   * to match and call sites fall through to the untyped fallback overload
+   * below. TypeScript's overload resolution is "first success wins", so the
+   * constraint error on this overload does not surface. Typed param inference
+   * still works for valid cases; typo detection via the type system would
+   * require a different, more invasive design and is intentionally out of
+   * scope here.
+   */
+  factory<const K extends string, const Deps extends readonly (keyof Registry & string)[], Return>(
+    name: K,
+    invokable: readonly [...Deps, (...args: ResolveDeps<Registry, Deps>) => Return],
+  ): TypedModule<Registry & { [P in K]: Return }, Name, Requires>;
+
+  /**
+   * `$inject`-annotated factory with deps validated against `Registry`. The
+   * function's `$inject` property must be a `readonly` literal tuple whose
+   * entries are keys of `Registry`; the function's parameters are validated
+   * against {@link ResolveDeps}.
+   */
+  factory<const K extends string, const Inject extends readonly (keyof Registry & string)[], Return>(
+    name: K,
+    invokable: ((...args: ResolveDeps<Registry, Inject>) => Return) & { $inject: Inject },
+  ): TypedModule<Registry & { [P in K]: Return }, Name, Requires>;
+
+  /**
+   * Untyped fallback — used when deps can't be validated statically (e.g.
+   * cross-module deps from a `requires` dependency, wide `string[]` `$inject`
+   * properties, or explicit `.factory<'name', Shape>(...)` return annotations).
+   */
+  factory<K extends string, Return>(
+    name: K,
+    invokable: Invokable<Return>,
+  ): TypedModule<Registry & { [P in K]: Return }, Name, Requires>;
 }
 
 /**
@@ -146,10 +238,18 @@ export class Module<
 export function createModule<const TName extends string, const TRequires extends readonly string[] = readonly []>(
   name: TName,
   requires: TRequires = [] as unknown as TRequires,
-): Module<Record<string, never>, TName, TRequires> {
-  const module = new Module<Record<string, never>, TName, TRequires>(name, requires);
+  // eslint-disable-next-line @typescript-eslint/no-empty-object-type -- see note on the `Module` class declaration for why `{}` is the correct empty-registry starting type.
+): TypedModule<{}, TName, TRequires> {
+  // eslint-disable-next-line @typescript-eslint/no-empty-object-type -- see above.
+  const module = new Module<{}, TName, TRequires>(name, requires);
   registry.set(name, module as unknown as AnyModule);
-  return module;
+  // Cast through `unknown` to expose the same runtime instance under the
+  // typed-factory `TypedModule` view. The underlying `Module` class method is
+  // untyped (for variance reasons — see the class's `factory` JSDoc); the
+  // typed overloads live on `TypedModule` and are applied only from this
+  // public entry point.
+  // eslint-disable-next-line @typescript-eslint/no-empty-object-type -- see above.
+  return module as unknown as TypedModule<{}, TName, TRequires>;
 }
 
 /**

--- a/src/di/module.ts
+++ b/src/di/module.ts
@@ -1,3 +1,5 @@
+import type { Invokable } from './di-types';
+
 /**
  * Recipe types supported by the module system. At Slice 1 only the identifier
  * strings are needed -- the actual `value`, `constant`, and `factory` methods
@@ -97,6 +99,32 @@ export class Module<
   constant<K extends string, T>(name: K, value: T): Module<Registry & { [P in K]: T }, Name, Requires> {
     this.invokeQueue.push(['constant', name, value]);
     return this as unknown as Module<Registry & { [P in K]: T }, Name, Requires>;
+  }
+
+  /**
+   * Register a factory function under `name`. The factory will be called by the
+   * injector to produce the service instance, with its declared dependencies
+   * resolved and passed in. The factory is a {@link Invokable} — either an
+   * array-style annotation `['dep1', 'dep2', fn]` or a function with a
+   * `$inject` property. Unlike `value` and `constant`, which store the literal
+   * argument, `factory` registrations are lazy: the function runs only when
+   * the service is first requested, and the result is cached as a singleton.
+   *
+   * `Return` is inferred from the trailing function of the supplied invokable
+   * so that `injector.get(name)` resolves to the factory's actual return type
+   * without any explicit annotation. Callers may still provide `Return`
+   * explicitly (e.g. `.factory<'svc', MyShape>(...)`) as an escape hatch.
+   *
+   * @param name - The name to register the factory under.
+   * @param invokable - The factory, as an array-style annotation or an
+   *   `$inject`-annotated function.
+   */
+  factory<K extends string, Return>(
+    name: K,
+    invokable: Invokable<Return>,
+  ): Module<Registry & { [P in K]: Return }, Name, Requires> {
+    this.invokeQueue.push(['factory', name, invokable]);
+    return this as unknown as Module<Registry & { [P in K]: Return }, Name, Requires>;
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,13 +3,7 @@ export * from './core/index';
 export { parse } from './parser/index';
 export type { ExpressionFn, Token, ASTNode } from './parser/index';
 
-export {
-  Module,
-  createModule,
-  getModule,
-  resetRegistry,
-  createInjector,
-} from './di/index';
+export { Module, createModule, getModule, resetRegistry, createInjector } from './di/index';
 export type {
   AnyModule,
   InvokeQueueEntry,

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,3 +2,24 @@ export * from './core/index';
 
 export { parse } from './parser/index';
 export type { ExpressionFn, Token, ASTNode } from './parser/index';
+
+export {
+  Module,
+  createModule,
+  getModule,
+  resetRegistry,
+  createInjector,
+} from './di/index';
+export type {
+  AnyModule,
+  InvokeQueueEntry,
+  RecipeType,
+  TypedModule,
+  MergeRegistries,
+  Annotated,
+  Injector,
+  Invokable,
+  InvokableArray,
+  ModuleAPI,
+  ResolveDeps,
+} from './di/index';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,8 @@
     "sourceMap": true,
     "paths": {
       "@core/*": ["./src/core/*"],
-      "@parser/*": ["./src/parser/*"]
+      "@parser/*": ["./src/parser/*"],
+      "@di/*": ["./src/di/*"]
     }
   },
   "include": ["src"],

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
     alias: {
       '@core': path.resolve(__dirname, 'src/core'),
       '@parser': path.resolve(__dirname, 'src/parser'),
+      '@di': path.resolve(__dirname, 'src/di'),
     },
   },
   test: {


### PR DESCRIPTION
## Summary

- **Spec 007 — Dependency Injection Foundation**: Complete implementation of the DI system covering module registry, injector, and recipes (value, constant, factory). All 37 functional spec acceptance criteria verified.
- **Typed builder pattern**: Each \`.value()\`/\`.constant()\`/\`.factory()\` call widens the module's \`Registry\` type. \`injector.get('name')\` infers the return type without explicit generics.
- **Typed \`invoke\` callback parameters**: \`injector.invoke(['name', (name) => ...])\` automatically infers \`name: string\` from the injector's registry — verified via LSP and \`expectTypeOf\`.
- **Circular dependency detection**: Resolution path stack with \`try/finally\` balance, full chain in error messages (\`Circular dependency: A <- B <- C <- A\`).
- **ES module API**: No global \`angular\` namespace — \`createModule\` / \`getModule\` / \`createInjector\` are named exports, consistent with the rest of the codebase. A dedicated AngularJS compatibility layer milestone will wrap these later.
- **Multi-entry Rollup build**: Fixed a pre-existing mismatch where \`package.json\` \`exports\` promised subpath entries that didn't exist on disk. Build now produces root + core + di + parser + compiler bundles in ESM, CJS, and \`.d.ts\` formats (15 dist artifacts).
- **505 tests passing** across 4 test files (up from 398 before this spec).

### Scope

- ✅ \`value\`, \`constant\`, \`factory\` recipes
- ✅ Module dependency graph walking (transitive, diamond, cycle-safe)
- ✅ Lazy factory resolution with singleton caching
- ✅ \`$inject\` property and array-style annotations
- ✅ Full type inference: module registry, injector.get, invoke callback params, factory return types
- ✅ Compile-time \`@ts-expect-error\` coverage for unregistered key rejection
- ⏭️ \`service\`, \`provider\`, \`decorator\` recipes deferred to spec 008
- ⏭️ \`config()\` / \`run()\` blocks deferred to spec 008
- ⏭️ \`angular\` namespace compatibility layer deferred to the final roadmap phase

## Test plan

- [x] \`pnpm lint\` passes
- [x] \`pnpm typecheck\` passes
- [x] \`pnpm test\` passes (505 tests)
- [x] \`pnpm build\` succeeds — all 15 subpath artifacts generated
- [x] \`dist/esm/di/index.mjs\`, \`dist/cjs/di/index.cjs\`, \`dist/types/di/index.d.ts\` all exist
- [x] All 37 acceptance criteria in \`functional-spec.md\` verified and marked \`[x]\`
- [x] Spec 007 status set to Completed
- [x] Roadmap updated — Module System and Injector marked done, Recipes/Config-Run annotated for spec 008

🤖 Generated with [Claude Code](https://claude.com/claude-code)